### PR TITLE
Add pygame rendering and keyboard controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,13 @@ _A Reinforcement Learning Lab for Next-Gen AI Racers_
 - 🖥️ Python 3.8+  
 - 🏎️ Gymnasium (Reinforcement Learning framework)  
 - 🧠 PyTorch / TensorFlow (for AI models)  
-- 🎵 SimpleAudio (for binaural effects)  
-- 📡 ZeroMQ / WebSockets (for live AI telemetry)  
+- 🎵 SimpleAudio (for binaural effects)
+- 🎮 Pygame (for optional graphics)
+- 📡 ZeroMQ / WebSockets (for live AI telemetry)
 
 🔽 **Install Dependencies**
 ```bash
-pip install gymnasium numpy torch transformers simpleaudio zmq
+pip install gymnasium numpy torch transformers simpleaudio pygame zmq
 ```
 
 🚀 **Run a Test Race**

--- a/main.py
+++ b/main.py
@@ -4,13 +4,27 @@ main.py
 Provides a simple training or demo loop to show usage of the PolePositionEnv.
 """
 
+import argparse
+try:
+    import pygame  # optional for input
+except Exception:  # pragma: no cover - optional dependency may be missing
+    pygame = None
+
 import gym
 import numpy as np
 from pole_position_env import PolePositionEnv
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--ai", action="store_true", help="Control Car 0 with AI instead of keyboard"
+    )
+    args = parser.parse_args()
+
     # Create environment
     env = PolePositionEnv(render_mode="human")
+
+    human_control = not args.ai and pygame is not None
 
     num_episodes = 5
     for ep in range(num_episodes):
@@ -19,10 +33,20 @@ def main():
         total_reward = 0.0
         steps = 0
         while not done:
-            # For demonstration: random action for Car 0
-            action = env.action_space.sample()
+            if human_control:
+                pygame.event.pump()
+                keys = pygame.key.get_pressed()
+                throttle = keys[pygame.K_UP]
+                brake = keys[pygame.K_DOWN]
+                steer = 0.0
+                if keys[pygame.K_LEFT]:
+                    steer -= 0.5
+                if keys[pygame.K_RIGHT]:
+                    steer += 0.5
+                action = (throttle, brake, steer)
+            else:
+                action = env.action_space.sample()
 
-            # Step environment
             obs, reward, done, trunc, info = env.step(action)
             total_reward += reward
             steps += 1
@@ -31,7 +55,6 @@ def main():
 
         print(f"Episode {ep+1} finished in {steps} steps with reward={total_reward:.2f}")
 
-    # Cleanup, especially if there's ongoing audio
     env.close()
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add optional dependency on pygame and update README installation steps
- allow richer actions (throttle, brake, steering) in environment
- draw cars and track using pygame when available
- handle pygame gracefully when missing
- support keyboard input in `main.py`

## Testing
- `python -m compileall -q .`
- `python main.py --ai`

------
https://chatgpt.com/codex/tasks/task_e_684815f1d680832482edf3b9a18df35f