### PR TITLE
Add lap timer and scoreboard

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,8 @@ def main():
 
         print(f"Episode {ep+1} finished in {steps} steps with reward={total_reward:.2f}")
 
-    # Cleanup, especially if there's ongoing audio
+    # Print summary for the final episode and clean up
+    env._summarize_episode()
     env.close()
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add timing and lap tracking to `PolePositionEnv`
- show race timer and best lap in `render`
- summarise each episode and maintain simple high score list
- display summary at the end of `main`

## Testing
- `python -m py_compile *.py`
- `python main.py` *(fails without gym, so installed dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684815f7eba08324b71286ab5a5ea4b5