### PR TITLE
Add manual gear shifting feature

### DIFF
--- a/super_pole_position/agents/base_llm_agent.py
+++ b/super_pole_position/agents/base_llm_agent.py
@@ -18,4 +18,9 @@ class NullAgent(BaseLLMAgent):
         # Simple policy: throttle until half max speed, no steering
         speed = observation[2]
         throttle = speed < 5.0
-        return {"throttle": int(throttle), "brake": int(not throttle), "steer": 0.0}
+        return {
+            "throttle": int(throttle),
+            "brake": int(not throttle),
+            "steer": 0.0,
+            "gear": 0,
+        }

--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -101,14 +101,17 @@ class PolePositionEnv(gym.Env):
         prev_obs = self._get_obs()
 
         # ---- Car 0 (Player / Random) ----
-        throttle, brake, steer = False, False, 0.0
+        throttle, brake, steer, gear_cmd = False, False, 0.0, 0
         if isinstance(action, (tuple, list)):
             if len(action) >= 3:
                 throttle, brake, steer = bool(action[0]), bool(action[1]), float(action[2])
+            if len(action) >= 4:
+                gear_cmd = int(action[3])
         elif isinstance(action, dict):
             throttle = bool(action.get("throttle", False))
             brake = bool(action.get("brake", False))
             steer = float(action.get("steer", 0.0))
+            gear_cmd = int(action.get("gear", 0))
         else:
             if action == 0:
                 throttle = True
@@ -116,6 +119,7 @@ class PolePositionEnv(gym.Env):
                 brake = True
             # else action==2 => no action
 
+        self.cars[0].shift(gear_cmd)
         self.cars[0].apply_controls(throttle, brake, steer, dt=1.0)
 
         # ---- Car 1 (AI) ----

--- a/super_pole_position/matchmaking/arena.py
+++ b/super_pole_position/matchmaking/arena.py
@@ -15,7 +15,12 @@ def run_episode(env: PolePositionEnv, agents: Tuple[BaseLLMAgent, BaseLLMAgent])
     total = 0.0
     while not done:
         action0 = agents[0].act(obs)
-        action0_tuple = (action0["throttle"], action0["brake"], action0["steer"])
+        action0_tuple = (
+            action0.get("throttle", 0),
+            action0.get("brake", 0),
+            action0.get("steer", 0.0),
+            action0.get("gear", 0),
+        )
         obs, reward, done, _, _ = env.step(action0_tuple)
         total += reward
     env.close()

--- a/super_pole_position/physics/car.py
+++ b/super_pole_position/physics/car.py
@@ -17,8 +17,15 @@ class Car:
         self.angle = angle  # Radians; 0 means facing 'east' by convention
         self.speed = speed
         self.acceleration = 2.0
-        self.max_speed = 15.0
+        # Two gear ratios: index 0=LOW, 1=HIGH
+        self.gear_max = [8.0, 15.0]
+        self.gear = 0
+        self.max_speed = self.gear_max[-1]
         self.turn_rate = 2.0  # rad/sec
+
+    def shift(self, change: int) -> None:
+        """Change gear by ``change`` amount (e.g. -1, 0, +1)."""
+        self.gear = min(max(self.gear + change, 0), len(self.gear_max) - 1)
 
     def apply_controls(self, throttle: bool, brake: bool, steering: float, dt: float = 1.0):
         """
@@ -34,11 +41,12 @@ class Car:
         if brake:
             self.speed -= self.acceleration * dt
 
-        # Clamp speed
+        # Clamp speed by current gear
+        max_speed = self.gear_max[self.gear]
         if self.speed < 0.0:
             self.speed = 0.0
-        elif self.speed > self.max_speed:
-            self.speed = self.max_speed
+        elif self.speed > max_speed:
+            self.speed = max_speed
 
         # Steering
         self.angle += steering * self.turn_rate * dt
@@ -48,3 +56,4 @@ class Car:
         dy = self.speed * math.sin(self.angle) * dt
         self.x += dx
         self.y += dy
+

--- a/tests/test_gear_shift.py
+++ b/tests/test_gear_shift.py
@@ -1,0 +1,14 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from super_pole_position.physics.car import Car
+
+
+def test_shift_changes_max_speed():
+    car = Car()
+    # low gear max ~8
+    car.apply_controls(True, False, 0.0, dt=1.0)
+    assert car.speed <= car.gear_max[0]
+    car.shift(1)
+    for _ in range(10):
+        car.apply_controls(True, False, 0.0, dt=1.0)
+    assert car.speed <= car.gear_max[1]


### PR DESCRIPTION
## Summary
- implement two-gear model in `Car`
- parse gear change commands in env step
- pass gear info through arena helper
- extend `NullAgent` with neutral gear action
- add unit test for gear shifting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848cab0a2008324b9cf39dcda5bb019