### PR TITLE
feat(ui): title menu & options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ spp qualify --agent null --track fuji
 ![](docs.gif)
 
 
+### Title Menu
+Running with `--render` opens a simple title screen. Use the arrow keys to set
+**difficulty**, toggle **audio**, choose a **track**, and adjust **volume**.
+Press **Enter** to begin or **Esc** to quit.
+
+
 🔥 **Only the fastest and smartest AIs survive. Are you ready to build the ultimate racing intelligence?** 🔥  
 
 ---

--- a/super_pole_position/cli.py
+++ b/super_pole_position/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 from pathlib import Path
 
 from .agents.base_llm_agent import NullAgent
@@ -16,10 +17,12 @@ def main() -> None:
     q = sub.add_parser("qualify")
     q.add_argument("--agent", default="null")
     q.add_argument("--track", default="fuji")
+    q.add_argument("--render", action="store_true")
 
     r = sub.add_parser("race")
     r.add_argument("--agent", default="null")
     r.add_argument("--track", default="fuji")
+    r.add_argument("--render", action="store_true")
 
     sub.add_parser("hiscore")
     sub.add_parser("reset-scores")
@@ -38,6 +41,17 @@ def main() -> None:
         return
 
     if args.cmd == "qualify":
+        if args.render:
+            import pygame
+            from .ui import menu
+            pygame.init()
+            screen = pygame.display.set_mode((640, 480))
+            cfg = menu.main_loop(screen)
+            pygame.quit()
+            if cfg is None:
+                return
+            args.track = cfg.get("track", args.track)
+            os.environ["AUDIO"] = "1" if cfg.get("audio", True) else "0"
         env = PolePositionEnv(render_mode="human", mode="qualify", track_name=args.track)
         agent = NullAgent()
         run_episode(env, (agent, agent))
@@ -47,6 +61,17 @@ def main() -> None:
         env.close()
         print(metrics)
     else:
+        if args.render:
+            import pygame
+            from .ui import menu
+            pygame.init()
+            screen = pygame.display.set_mode((640, 480))
+            cfg = menu.main_loop(screen)
+            pygame.quit()
+            if cfg is None:
+                return
+            args.track = cfg.get("track", args.track)
+            os.environ["AUDIO"] = "1" if cfg.get("audio", True) else "0"
         env = PolePositionEnv(render_mode="human", mode="race", track_name=args.track)
         agent = NullAgent()
         run_episode(env, (agent, agent))

--- a/super_pole_position/ui/menu.py
+++ b/super_pole_position/ui/menu.py
@@ -1,0 +1,136 @@
+"""Simple title menu with options and hi-score display."""
+from __future__ import annotations
+
+import os
+import random
+from pathlib import Path
+
+try:
+    import pygame  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    pygame = None
+
+from ..evaluation.scores import load_scores
+
+
+class MenuState:
+    """Headless-friendly menu state machine."""
+
+    options = {
+        "difficulty": ["beginner", "expert"],
+        "audio": ["on", "off"],
+        "track": ["fuji", "seaside", "random"],
+        "volume": list(range(0, 110, 10)),
+    }
+    order = ["difficulty", "audio", "track", "volume"]
+
+    def __init__(self) -> None:
+        self.values = {
+            "difficulty": 0,
+            "audio": 0,
+            "track": 0,
+            "volume": 10,
+        }
+        self.selected = 0
+
+    def visible(self) -> list[str]:
+        if self.options_for("audio")[self.values["audio"]] == "off":
+            return ["difficulty", "audio", "track"]
+        return self.order
+
+    def options_for(self, name: str) -> list:
+        return self.options[name]
+
+    def handle(self, key: str):
+        key = key.upper()
+        if key == "UP":
+            self.selected = (self.selected - 1) % len(self.visible())
+        elif key == "DOWN":
+            self.selected = (self.selected + 1) % len(self.visible())
+        elif key in {"LEFT", "RIGHT"}:
+            name = self.visible()[self.selected]
+            opts = self.options_for(name)
+            delta = -1 if key == "LEFT" else 1
+            self.values[name] = (self.values[name] + delta) % len(opts)
+        elif key in {"ENTER", "SPACE"}:
+            return self.config()
+        elif key in {"ESC", "Q"}:
+            return None
+        return "CONTINUE"
+
+    def config(self) -> dict:
+        return {
+            "difficulty": self.options_for("difficulty")[self.values["difficulty"]],
+            "audio": self.options_for("audio")[self.values["audio"]] == "on",
+            "track": self.options_for("track")[self.values["track"]],
+            "volume": self.options_for("volume")[self.values["volume"]],
+        }
+
+
+# --- pygame frontend -----------------------------------------------------
+
+def _load_backdrop(rng: random.Random) -> pygame.Surface | None:
+    if not pygame:
+        return None
+    bg_dir = Path(__file__).resolve().parent.parent / "assets" / "title_bg"
+    files = list(bg_dir.glob("*.png"))
+    if files:
+        img = pygame.image.load(str(rng.choice(files)))
+        return img.convert()
+    # generate placeholder if no images bundled
+    surf = pygame.Surface((screen_width := 320, 240))
+    surf.fill((rng.randrange(256), rng.randrange(256), rng.randrange(256)))
+    return surf
+
+
+def main_loop(screen, seed: int | None = None) -> dict | None:
+    """Interactive title menu loop. Returns config or None if cancelled."""
+    if not pygame:
+        return {
+            "difficulty": "beginner",
+            "audio": os.environ.get("AUDIO", "1") != "0",
+            "track": "fuji",
+            "volume": 100,
+        }
+
+    clock = pygame.time.Clock()
+    rng = random.Random(seed)
+    backdrop = _load_backdrop(rng)
+    state = MenuState()
+    font = pygame.font.SysFont(None, 24)
+    x_offset = 0
+    running = True
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                return None
+            if event.type == pygame.KEYDOWN:
+                name = pygame.key.name(event.key).upper()
+                result = state.handle(name)
+                if result is None or isinstance(result, dict):
+                    return result
+                if name == "H":
+                    scores = load_scores(None)
+                    print("=== HI-SCORES ===")
+                    for i, s in enumerate(scores, 1):
+                        print(f"{i:2d}. {s['name']} {s['score']}")
+        if backdrop:
+            w = backdrop.get_width()
+            screen.blit(backdrop, (-x_offset % w, 0))
+            if w < screen.get_width():
+                screen.blit(backdrop, ((-x_offset % w) + w, 0))
+            x_offset += 1
+        screen.fill((0, 0, 0)) if not backdrop else None
+        # draw options
+        y = 50
+        for i, opt in enumerate(state.visible()):
+            val = state.options_for(opt)[state.values[opt]]
+            prefix = "> " if i == state.selected else "  "
+            text = font.render(f"{prefix}{opt}: {val}", True, (255, 255, 255))
+            screen.blit(text, (50, y))
+            y += 30
+        press = font.render("PRESS ENTER", True, (255, 255, 0))
+        screen.blit(press, (50, y + 20))
+        pygame.display.flip()
+        clock.tick(30)
+    return None

--- a/tests/test_menu_config.py
+++ b/tests/test_menu_config.py
@@ -1,0 +1,23 @@
+from super_pole_position.ui.menu import MenuState
+
+
+def test_menu_navigation_and_config():
+    state = MenuState()
+    # set difficulty to expert
+    state.handle('RIGHT')
+    # move to audio and turn off
+    state.handle('DOWN')
+    state.handle('RIGHT')
+    # move to track and choose seaside
+    state.handle('DOWN')
+    state.handle('RIGHT')
+    # confirm
+    cfg = state.handle('ENTER')
+    assert cfg['difficulty'] == 'expert'
+    assert cfg['audio'] is False
+    assert cfg['track'] == 'seaside'
+
+
+def test_menu_escape_returns_none():
+    state = MenuState()
+    assert state.handle('ESC') is None


### PR DESCRIPTION
## Summary
- add placeholder title backdrops
- implement title menu logic and config handling
- start title screen from CLI when `--render` flag is used
- document menu usage in README
- test menu state navigation
- generate fallback backdrops when none exist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848f5f4712c8324b40648e1d416f739