### PR TITLE
fix: green CI & PEP‑8 compliance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,9 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install
-        run: pip install -e .[dev]
+        run: |
+          pip install pygame~=2.5.2 --only-binary=:all:
+          pip install -e .[dev]
       - name: Test
         run: |
           pytest -q --cov=super_pole_position --cov-fail-under=80

--- a/DEBUG.md
+++ b/DEBUG.md
@@ -1,0 +1,13 @@
+# Manual run logs
+
+## Headless race
+```
+{'reward': 35.13, 'qualifying_time': None, 'passes': 0, 'crashes': 0, 'gear_shifts': 0}
+
+```
+
+## Render race without pygame
+```
+pygame required for --render
+
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,9 @@ super-pole-position = "super_pole_position.cli:main"
 
 [tool.setuptools.packages.find]
 exclude = ["assets*"]
+
+[tool.ruff]
+line-length = 88
+
+[tool.black]
+line-length = 88

--- a/super_pole_position/evaluation/scores.py
+++ b/super_pole_position/evaluation/scores.py
@@ -9,6 +9,8 @@ _DEFAULT_FILE = Path(__file__).resolve().parent / "scores.json"
 
 
 def load_scores(file: Path | None = None) -> List[Dict]:
+    """Return list of score dicts from ``file``."""
+
     file = file or _DEFAULT_FILE
     if file.exists():
         try:
@@ -20,6 +22,8 @@ def load_scores(file: Path | None = None) -> List[Dict]:
 
 
 def update_scores(file: Path | None, name: str, score: int) -> None:
+    """Record ``score`` for ``name`` in ``file``."""
+
     file = file or _DEFAULT_FILE
     scores = load_scores(file)
     scores.append({"name": name, "score": int(score)})
@@ -28,5 +32,7 @@ def update_scores(file: Path | None, name: str, score: int) -> None:
 
 
 def reset_scores(file: Path | None = None) -> None:
+    """Clear all scores in ``file``."""
+
     file = file or _DEFAULT_FILE
     file.write_text(json.dumps({"scores": []}, indent=2))

--- a/super_pole_position/matchmaking/arena.py
+++ b/super_pole_position/matchmaking/arena.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Iterable, Tuple
+from typing import Tuple
 
 from ..envs.pole_position import PolePositionEnv
 from ..agents.base_llm_agent import BaseLLMAgent
 
 
-def run_episode(env: PolePositionEnv, agents: Tuple[BaseLLMAgent, BaseLLMAgent]) -> float:
+def run_episode(
+    env: PolePositionEnv, agents: Tuple[BaseLLMAgent, BaseLLMAgent]
+) -> float:
     """Run one episode and return cumulative reward for agent 0."""
     obs, _ = env.reset()
     done = False

--- a/super_pole_position/physics/__init__.py
+++ b/super_pole_position/physics/__init__.py
@@ -1,3 +1,7 @@
+"""Convenience exports for common physics objects."""
+
 from .car import Car
 from .track import Track
 from .traffic_car import TrafficCar
+
+__all__ = ["Car", "Track", "TrafficCar"]

--- a/super_pole_position/ui/arcade.py
+++ b/super_pole_position/ui/arcade.py
@@ -1,4 +1,5 @@
 """Minimal pygame viewer used during local races."""
+
 import os
 
 try:
@@ -8,6 +9,8 @@ except Exception:  # pragma: no cover
 
 
 def available() -> bool:
+    """Return ``True`` if pygame is installed."""
+
     return pygame is not None
 
 
@@ -15,12 +18,17 @@ class ArcadeRenderer:
     """Draw HUD and scenery layers using pygame."""
 
     def __init__(self, screen):
+        """Create a renderer bound to ``screen``."""
+
         self.screen = screen
         self.font = pygame.font.SysFont(None, 24) if pygame else None
         self.scenery = []
         if pygame:
             import pathlib
-            sc_dir = pathlib.Path(__file__).resolve().parent.parent / "assets" / "scenery"
+
+            sc_dir = (
+                pathlib.Path(__file__).resolve().parent.parent / "assets" / "scenery"
+            )
             for img in sc_dir.glob("*.png"):
                 try:
                     self.scenery.append(pygame.image.load(str(img)))
@@ -35,6 +43,8 @@ class ArcadeRenderer:
             self.crash_sound = silent
 
     def draw(self, env) -> None:
+        """Render the current environment state."""
+
         if not pygame:
             return
         # parallax scenery
@@ -52,7 +62,6 @@ class ArcadeRenderer:
 
         # audio channels
         if hasattr(self, "channels"):
-            pitch = env.cars[0].speed / env.cars[0].gear_max[-1]
             self.channels[0].play(self.engine_sound, loops=-1)
             if getattr(env, "skid_timer", 0) > 0 and not self.channels[1].get_busy():
                 self.channels[1].play(self.skid_sound)

--- a/super_pole_position/ui/menu.py
+++ b/super_pole_position/ui/menu.py
@@ -1,4 +1,5 @@
 """Simple title menu with options and hi-score display."""
+
 from __future__ import annotations
 
 import os
@@ -34,14 +35,20 @@ class MenuState:
         self.selected = 0
 
     def visible(self) -> list[str]:
+        """Return list of option names currently visible."""
+
         if self.options_for("audio")[self.values["audio"]] == "off":
             return ["difficulty", "audio", "track"]
         return self.order
 
     def options_for(self, name: str) -> list:
+        """Return allowed values for option ``name``."""
+
         return self.options[name]
 
     def handle(self, key: str):
+        """Update state in response to a keypress."""
+
         key = key.upper()
         if key == "UP":
             self.selected = (self.selected - 1) % len(self.visible())
@@ -59,6 +66,8 @@ class MenuState:
         return "CONTINUE"
 
     def config(self) -> dict:
+        """Return a configuration dictionary representing the current state."""
+
         return {
             "difficulty": self.options_for("difficulty")[self.values["difficulty"]],
             "audio": self.options_for("audio")[self.values["audio"]] == "on",
@@ -69,7 +78,10 @@ class MenuState:
 
 # --- pygame frontend -----------------------------------------------------
 
+
 def _load_backdrop(rng: random.Random) -> pygame.Surface | None:
+    """Return a backdrop surface or ``None`` when pygame is unavailable."""
+
     if not pygame:
         return None
     bg_dir = Path(__file__).resolve().parent.parent / "assets" / "title_bg"
@@ -78,7 +90,7 @@ def _load_backdrop(rng: random.Random) -> pygame.Surface | None:
         img = pygame.image.load(str(rng.choice(files)))
         return img.convert()
     # generate placeholder if no images bundled
-    surf = pygame.Surface((screen_width := 320, 240))
+    surf = pygame.Surface((320, 240))
     surf.fill((rng.randrange(256), rng.randrange(256), rng.randrange(256)))
     return surf
 

--- a/tests/test_cli_headless.py
+++ b/tests/test_cli_headless.py
@@ -1,0 +1,11 @@
+import subprocess
+import sys
+
+
+def test_cli_headless():
+    result = subprocess.run(
+        [sys.executable, "-m", "super_pole_position.cli", "race"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode == 0

--- a/tests/test_cli_render_skip.py
+++ b/tests/test_cli_render_skip.py
@@ -1,0 +1,12 @@
+import subprocess
+import sys
+
+
+def test_cli_render_skip(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pygame", None)
+    result = subprocess.run(
+        [sys.executable, "-m", "super_pole_position.cli", "race", "--render"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode == 1

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,7 +1,7 @@
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-import numpy as np
 from super_pole_position.envs.pole_position import PolePositionEnv
 
 

--- a/tests/test_gear_shift.py
+++ b/tests/test_gear_shift.py
@@ -1,4 +1,6 @@
-import os, sys
+import os
+import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from super_pole_position.physics.car import Car
 

--- a/tests/test_lap_counter.py
+++ b/tests/test_lap_counter.py
@@ -1,4 +1,6 @@
-import os, sys
+import os
+import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from super_pole_position.envs.pole_position import PolePositionEnv
 

--- a/tests/test_offroad_speed.py
+++ b/tests/test_offroad_speed.py
@@ -1,4 +1,6 @@
-import os, sys
+import os
+import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from super_pole_position.envs.pole_position import PolePositionEnv
 
@@ -9,7 +11,6 @@ def test_offroad_speed():
     env.start_timer = 0
     env.cars[0].y = 1.0  # near edge -> off-road
     env.cars[0].gear = 1
-    speed_before = env.cars[0].speed
     env.step((True, False, 0.0))
     assert env.cars[0].speed < env.cars[0].acceleration
     env.close()

--- a/tests/test_score_accumulates.py
+++ b/tests/test_score_accumulates.py
@@ -1,4 +1,6 @@
-import os, sys
+import os
+import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from super_pole_position.envs.pole_position import PolePositionEnv
 

--- a/tests/test_slipstream_boost.py
+++ b/tests/test_slipstream_boost.py
@@ -1,4 +1,6 @@
-import os, sys
+import os
+import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from super_pole_position.envs.pole_position import PolePositionEnv
 

--- a/tests/test_timer_checkpoint.py
+++ b/tests/test_timer_checkpoint.py
@@ -1,4 +1,6 @@
-import os, sys
+import os
+import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from super_pole_position.envs.pole_position import PolePositionEnv
 

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from super_pole_position.physics.track import Track
 from super_pole_position.physics.car import Car
@@ -25,10 +26,3 @@ def test_distance():
 def test_load_named_track():
     track = Track.load("fuji")
     assert track.width > 0
-
-
-def test_load_named_track(tmp_path):
-    track_file = tmp_path / "foo.json"
-    track_file.write_text('{"segments": [[0,0],[5,0],[5,5],[0,5]]}')
-    TrackPath = Track.load
-    # monkeypatch path to tmp

--- a/tests/test_traffic_collision.py
+++ b/tests/test_traffic_collision.py
@@ -1,4 +1,6 @@
-import os, sys
+import os
+import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from super_pole_position.envs.pole_position import PolePositionEnv
 


### PR DESCRIPTION
## Summary
- handle optional pygame dependency in CLI
- document public functions and clean up code
- add headless/run CLI regression tests
- format codebase and update lint config
- run CI with pygame wheels for headless mode

## Testing
- `ruff check super_pole_position/cli.py super_pole_position/evaluation/scores.py super_pole_position/matchmaking/arena.py super_pole_position/physics/__init__.py super_pole_position/ui/arcade.py super_pole_position/ui/menu.py tests/test_env.py tests/test_gear_shift.py tests/test_lap_counter.py tests/test_offroad_speed.py tests/test_score_accumulates.py tests/test_slipstream_boost.py tests/test_timer_checkpoint.py tests/test_track.py tests/test_traffic_collision.py tests/test_cli_headless.py tests/test_cli_render_skip.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492b1f6e408324b0aa3f58315e9391