### PR TITLE
Fix CI Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: '3.11'
       - name: Install
         run: |
           pip install pygame~=2.5.2 --only-binary=:all:


### PR DESCRIPTION
## Summary
- use Python 3.11 in CI

## Testing
- `pytest -q tests/test_car.py tests/test_env.py tests/test_gear_shift.py tests/test_hiscore_persistence.py tests/test_lap_counter.py tests/test_leaderboard.py tests/test_menu_config.py tests/test_offroad_speed.py tests/test_score_accumulates.py tests/test_slipstream_boost.py tests/test_timer_checkpoint.py tests/test_track.py tests/test_traffic_collision.py tests/test_ui.py tests/test_cli_headless.py tests/test_cli_render_skip.py`


------
https://chatgpt.com/codex/tasks/task_e_68492eb6a6388324b5766456f028b956