### PR TITLE
Add benchmark logger with step CSV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+benchmarks/*
+!benchmarks/README.md
+__pycache__/

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,12 @@
+# Benchmarks
+
+This directory stores episode logs generated during gameplay. Logs are organized
+by UTC date so results from different runs remain separated.
+
+For each completed episode two files are written:
+
+- `<timestamp>.json` – summary metrics such as reward, lap times and timing stats.
+- `<timestamp>-steps.csv` – per-step data capturing car positions, speeds and rewards.
+
+These files are produced automatically by `super_pole_position.evaluation.logger`
+and are useful for tracking historical performance.

--- a/super_pole_position/evaluation/logger.py
+++ b/super_pole_position/evaluation/logger.py
@@ -1,28 +1,47 @@
-"""Utility for writing simple JSON benchmark logs."""
+"""Utility for writing simple JSON/CSV benchmark logs."""
 
 from __future__ import annotations
 
+import csv
 import json
 from datetime import datetime
 from pathlib import Path
 
 from .metrics import summary
 
+# Root directory for benchmark files (can be patched in tests)
+BENCH_ROOT = Path("benchmarks")
 
-def log_episode(env, file: Path | None = None) -> Path:
-    """Write a JSON summary for ``env`` to ``file``.
+
+def log_episode(env, file: Path | None = None, step_file: Path | None = None) -> Path:
+    """Write a JSON summary and step CSV for ``env``.
 
     :param env: Environment with metrics attributes.
-    :param file: Optional explicit path. Defaults to ``benchmarks/YYYY-MM-DD/<timestamp>.json``.
+    :param file: Optional explicit path for the summary JSON. Defaults to
+        ``benchmarks/YYYY-MM-DD/<timestamp>.json``.
+    :param step_file: Optional explicit path for per-step CSV. Defaults to
+        ``benchmarks/YYYY-MM-DD/<timestamp>-steps.csv``.
     :return: Path to the file written.
     """
-    date_dir = Path("benchmarks") / datetime.utcnow().strftime("%Y-%m-%d")
+    date_dir = BENCH_ROOT / datetime.utcnow().strftime("%Y-%m-%d")
     date_dir.mkdir(parents=True, exist_ok=True)
     if file is None:
         timestamp = datetime.utcnow().strftime("%H%M%S")
         file = date_dir / f"{timestamp}.json"
+    if step_file is None:
+        step_file = date_dir / f"{file.stem}-steps.csv"
 
     data = summary(env)
     data["timestamp"] = datetime.utcnow().isoformat()
     file.write_text(json.dumps(data, indent=2))
+
+    # Per-step CSV log if env provides ``step_log``
+    if getattr(env, "step_log", None):
+        fields = list(env.step_log[0].keys()) if env.step_log else []
+        with step_file.open("w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=fields)
+            writer.writeheader()
+            for row in env.step_log:
+                writer.writerow(row)
+
     return file

--- a/tests/test_benchmark_logger.py
+++ b/tests/test_benchmark_logger.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from pathlib import Path
+
+from super_pole_position.envs.pole_position import PolePositionEnv
+from super_pole_position.evaluation import logger as bench_logger
+
+
+def test_log_episode_creates_files(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    bench_logger.BENCH_ROOT = Path("benchmarks")
+
+    env = PolePositionEnv(render_mode="human")
+    env.reset()
+    env.remaining_time = 0  # force done
+    env.step((0, 0, 0.0))
+    env.close()
+
+    date_dir = tmp_path / "benchmarks" / datetime.utcnow().strftime("%Y-%m-%d")
+    files = list(date_dir.iterdir())
+    assert any(f.suffix == ".json" for f in files)
+    assert any(f.suffix == ".csv" for f in files)


### PR DESCRIPTION
## Summary
- log benchmark episodes to JSON and per-step CSV
- add per-step logging data to `PolePositionEnv`
- document benchmark format
- test logging utility

## Testing
- `pytest -q tests/test_benchmark_logger.py`
- `pytest -q` *(fails: 5 passed, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684affc887d88324a7d938ec300f0a4c