### PR TITLE
Bug fixes and cleanup

### DIFF
--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -563,11 +563,12 @@ class PolePositionEnv(gym.Env):
             pass
 
     def _play_bgm_loop(self) -> None:
-        """Play background music once (placeholder loop)."""
+        """Start background music playback once."""
 
         if sa is None or self.bgm_wave is None:
             return
         try:
+            # simpleaudio lacks looping support; play once per reset
             self.bgm_wave.play()
         except Exception:  # pragma: no cover
             pass

--- a/super_pole_position/evaluation/logger.py
+++ b/super_pole_position/evaluation/logger.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import csv
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from .metrics import summary
@@ -23,16 +23,16 @@ def log_episode(env, file: Path | None = None, step_file: Path | None = None) ->
         ``benchmarks/YYYY-MM-DD/<timestamp>-steps.csv``.
     :return: Path to the file written.
     """
-    date_dir = BENCH_ROOT / datetime.utcnow().strftime("%Y-%m-%d")
+    date_dir = BENCH_ROOT / datetime.now(timezone.utc).strftime("%Y-%m-%d")
     date_dir.mkdir(parents=True, exist_ok=True)
     if file is None:
-        timestamp = datetime.utcnow().strftime("%H%M%S")
+        timestamp = datetime.now(timezone.utc).strftime("%H%M%S")
         file = date_dir / f"{timestamp}.json"
     if step_file is None:
         step_file = date_dir / f"{file.stem}-steps.csv"
 
     data = summary(env)
-    data["timestamp"] = datetime.utcnow().isoformat()
+    data["timestamp"] = datetime.now(timezone.utc).isoformat()
     file.write_text(json.dumps(data, indent=2))
 
     # Per-step CSV log if env provides ``step_log``


### PR DESCRIPTION
## Summary
- use timezone-aware datetime in benchmark logger
- clarify background music playback comments

## Testing
- `ruff check .`
- `SDL_VIDEODRIVER=dummy pytest tests/test_ascii_sprites.py::test_ascii_surface -q`

------
https://chatgpt.com/codex/tasks/task_e_684b37f21f708324829bc0acaed1ec45