### PR TITLE
Fix docs, UI position, and traffic test

### DIFF
--- a/super_pole_position/agents/controllers.py
+++ b/super_pole_position/agents/controllers.py
@@ -1,5 +1,5 @@
 """
-ai_controllers.py
+controllers.py
  
 Houses:
 - GPTPlanner: High-level strategy using a GPT model.
@@ -31,7 +31,7 @@ class GPTPlanner:
     def generate_plan(self, state_dict):
         """Return a textual plan for the next action."""
         if self.tokenizer is None or self.model is None:
-            # Fallback behaviour if transformers is unavailable
+            # Fallback behavior if transformers is unavailable
             return "target_speed 10"
 
         prompt = (

--- a/super_pole_position/ui/arcade.py
+++ b/super_pole_position/ui/arcade.py
@@ -269,7 +269,9 @@ class Pseudo3DRenderer:
                 self.screen.blit(lap_time_text, (lx, 30))
 
             lap_text = font.render(f"LAP {env.lap + 1}/4", True, (0, 255, 0))
-            pos = 1 if env.track.distance(player, other) < 0 else 2
+            p_prog = env.track.progress(player)
+            o_prog = env.track.progress(other)
+            pos = 1 if p_prog >= o_prog else 2
             pos_text = font.render(f"POS {pos}/2", True, (0, 255, 0))
             self.screen.blit(lap_text, (10, 50))
             self.screen.blit(pos_text, (10, 70))

--- a/tests/test_traffic_pathing.py
+++ b/tests/test_traffic_pathing.py
@@ -10,9 +10,11 @@ def test_traffic_ai_pathing():
     env.start_timer = 0
     car = env.traffic[0]
     car.y = 1.0  # force off center
+    start_offset = abs(car.y - env.track.height / 2)
     for _ in range(10):
         env.step((False, False, 0.0))
-    assert abs(car.y - env.track.height / 2) < env.track.height / 2
+    end_offset = abs(car.y - env.track.height / 2)
+    assert end_offset < start_offset
     env.close()
 
 


### PR DESCRIPTION
## Summary
- update file reference in controllers docstring
- fix American spelling of fallback behavior
- compute race position with lap progress
- check that traffic cars steer toward centerline

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b77fd9bc48324960492e909f1d41e