### PR TITLE
Improve pygame test handling

### DIFF
--- a/tests/test_ascii_sprites.py
+++ b/tests/test_ascii_sprites.py
@@ -1,4 +1,5 @@
-import pygame
+import pytest
+pygame = pytest.importorskip("pygame")
 from super_pole_position.ui.sprites import ascii_surface, CAR_ART
 
 

--- a/tests/test_benchmark_logger.py
+++ b/tests/test_benchmark_logger.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from super_pole_position.envs.pole_position import PolePositionEnv
@@ -15,7 +15,7 @@ def test_log_episode_creates_files(tmp_path, monkeypatch):
     env.step((0, 0, 0.0))
     env.close()
 
-    date_dir = tmp_path / "benchmarks" / datetime.utcnow().strftime("%Y-%m-%d")
+    date_dir = tmp_path / "benchmarks" / datetime.now(timezone.utc).strftime("%Y-%m-%d")
     files = list(date_dir.iterdir())
     assert any(f.suffix == ".json" for f in files)
     assert any(f.suffix == ".csv" for f in files)

--- a/tests/test_hud_render.py
+++ b/tests/test_hud_render.py
@@ -1,4 +1,5 @@
-import pygame
+import pytest
+pygame = pytest.importorskip("pygame")
 from super_pole_position.envs.pole_position import PolePositionEnv
 from super_pole_position.ui.arcade import Pseudo3DRenderer
 


### PR DESCRIPTION
## Summary
- skip pygame-based tests when pygame isn't available
- use timezone-aware date in benchmark logger test

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e241d93ec8324915942efc208df73