### PR TITLE
feat(arcade_parity): top-3 high-impact improvements

### DIFF
--- a/super_pole_position/evaluation/leaderboard.json
+++ b/super_pole_position/evaluation/leaderboard.json
@@ -1,1 +1,17 @@
-{"schema_version": 2, "results": []}
+{
+  "schema_version": 2,
+  "results": [
+    {
+      "name": "null-race",
+      "reward": 1.1,
+      "qualifying_time": null,
+      "passes": 0,
+      "crashes": 0,
+      "gear_shifts": 0,
+      "ai_offtrack": 0,
+      "avg_plan_ms": 0.0005506000093191687,
+      "avg_step_ms": 0.1612029999932929,
+      "tokens": 10
+    }
+  ]
+}

--- a/super_pole_position/evaluation/scores.json
+++ b/super_pole_position/evaluation/scores.json
@@ -1,1 +1,8 @@
-{"scores": []}
+{
+  "scores": [
+    {
+      "name": "null",
+      "score": 1100
+    }
+  ]
+}

--- a/tests/test_ascii_sprites.py
+++ b/tests/test_ascii_sprites.py
@@ -1,6 +1,6 @@
 import pytest
-pygame = pytest.importorskip("pygame")
-from super_pole_position.ui.sprites import ascii_surface, CAR_ART
+pygame = pytest.importorskip("pygame")  # noqa: E402
+from super_pole_position.ui.sprites import ascii_surface, CAR_ART  # noqa: E402
 
 
 def test_ascii_surface():

--- a/tests/test_explosion_anim.py
+++ b/tests/test_explosion_anim.py
@@ -1,0 +1,22 @@
+import types
+import pytest
+pygame = pytest.importorskip("pygame")  # noqa: E402
+from super_pole_position.ui.arcade import ArcadeRenderer  # noqa: E402
+
+
+def test_explosion_frame_indices():
+    pygame.display.init()
+    pygame.font.init()
+    screen = pygame.display.set_mode((64, 64))
+    import os
+    os.environ["AUDIO"] = "0"
+    renderer = ArcadeRenderer(screen)
+    renderer.explosion_sheet = pygame.Surface((160, 10))
+    env = types.SimpleNamespace(crash_duration=2.56, crash_timer=2.56)
+    indices = []
+    for i in range(16):
+        env.crash_timer = env.crash_duration - i * (env.crash_duration / 16) - 0.01
+        idx = renderer.draw_explosion(env, (0, 0))
+        indices.append(idx)
+    assert indices == list(range(16))
+    pygame.display.quit()

--- a/tests/test_hud_render.py
+++ b/tests/test_hud_render.py
@@ -1,7 +1,7 @@
 import pytest
-pygame = pytest.importorskip("pygame")
-from super_pole_position.envs.pole_position import PolePositionEnv
-from super_pole_position.ui.arcade import Pseudo3DRenderer
+pygame = pytest.importorskip("pygame")  # noqa: E402
+from super_pole_position.envs.pole_position import PolePositionEnv  # noqa: E402
+from super_pole_position.ui.arcade import Pseudo3DRenderer  # noqa: E402
 
 
 def test_hud_render_smoke():

--- a/tests/test_hud_score.py
+++ b/tests/test_hud_score.py
@@ -1,0 +1,35 @@
+import types
+import pytest
+pygame = pytest.importorskip("pygame")  # noqa: E402
+from super_pole_position.ui.arcade import ArcadeRenderer  # noqa: E402
+
+
+def test_hud_high_score_updates(monkeypatch):
+    pygame.display.init()
+    pygame.font.init()
+    screen = pygame.display.set_mode((160, 120))
+    import os
+    os.environ["AUDIO"] = "0"
+    renderer = ArcadeRenderer(screen)
+    env = types.SimpleNamespace(
+        score=123,
+        high_score=100,
+        cars=[types.SimpleNamespace(speed=0, gear=0)],
+        remaining_time=0.0,
+        lap_timer=None,
+        lap_flash=0.0,
+        last_lap_time=None,
+    )
+    class DummyFont:
+        def __init__(self):
+            self.texts = []
+
+        def render(self, text, aa, color):
+            self.texts.append(text)
+            return pygame.Surface((1, 1))
+
+    renderer.font = DummyFont()
+    renderer.draw_hud(env)
+    assert env.high_score == 123
+    assert any("SCORE 00123" in t and "HI 00123" in t for t in renderer.font.texts)
+    pygame.display.quit()

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,21 @@
+import types
+import pytest
+pygame = pytest.importorskip("pygame")  # noqa: E402
+from super_pole_position.ui.arcade import Pseudo3DRenderer  # noqa: E402
+
+
+def test_draw_road_polygon_offset():
+    pygame.display.init()
+    screen = pygame.display.set_mode((320, 240))
+    renderer = Pseudo3DRenderer(screen)
+    env = types.SimpleNamespace(
+        cars=[types.SimpleNamespace(angle=0.0, steering=0.5)],
+        track=types.SimpleNamespace(),
+    )
+    poly = renderer.draw_road_polygon(env)
+    width = screen.get_width()
+    road_top = width * 0.6 * 0.2
+    expected = 0.5 * (width / 4)
+    assert poly[2][0] == pytest.approx(width / 2 + expected + road_top / 2)
+    assert poly[3][0] == pytest.approx(width / 2 + expected - road_top / 2)
+    pygame.display.quit()


### PR DESCRIPTION
## Summary
- shift road vanishing point using curvature
- animate crash sprite sheet frame by frame
- display SCORE and HI-SCORE in HUD

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check .`
- `pyright .` *(fails: `Literal['track']` type errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e2b920848832483932ab05c27b706