### PR TITLE
feat(iteration-2): dynamic perspective, explosion animation, HUD & logging

### DIFF
--- a/super_pole_position/matchmaking/arena.py
+++ b/super_pole_position/matchmaking/arena.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from datetime import datetime, timezone
 from typing import Tuple
 
 from ..envs.pole_position import PolePositionEnv
@@ -37,6 +38,16 @@ def run_episode(
         obs, reward, done, _, _ = env.step(action0_tuple)
         total += reward
     env.episode_reward = total
+    date_dir = Path("benchmarks") / datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    date_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%H%M%S")
+    out = {
+        "agent": getattr(agents[0], "name", "agent"),
+        "track": getattr(env, "track_name", "unknown"),
+        "result": {"reward": total},
+        "perf": {"steps": env.current_step},
+    }
+    (date_dir / f"{ts}.json").write_text(json.dumps(out, indent=2))
     return total
 
 

--- a/tests/test_benchmark_logging.py
+++ b/tests/test_benchmark_logging.py
@@ -1,0 +1,20 @@
+import json
+from datetime import datetime, timezone
+import pytest  # noqa: F401
+
+from super_pole_position.matchmaking import arena
+from super_pole_position.envs.pole_position import PolePositionEnv
+from super_pole_position.agents.base_llm_agent import NullAgent
+
+
+def test_benchmark_logging(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    env = PolePositionEnv(render_mode="human")
+    env.reset()
+    agents = (NullAgent(), NullAgent())
+    arena.run_episode(env, agents)
+    date_dir = tmp_path / "benchmarks" / datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    files = list(date_dir.glob("*.json"))
+    assert files
+    data = json.loads(files[0].read_text())
+    assert {"agent", "track", "result", "perf"} <= data.keys()

--- a/tests/test_explosion_anim.py
+++ b/tests/test_explosion_anim.py
@@ -1,0 +1,26 @@
+import types
+import pytest  # noqa: F401
+
+pygame = pytest.importorskip("pygame")
+from super_pole_position.ui.arcade import ArcadeRenderer  # noqa: E402
+
+
+def test_explosion_frame_index(monkeypatch):
+    screen = pygame.Surface((32, 32))
+    renderer = ArcadeRenderer(screen)
+    renderer.explosion_sheet = pygame.Surface((160, 10))
+
+    env = types.SimpleNamespace(crash_duration=1.6, crash_timer=1.6)
+    rects = []
+
+    def fake_sub(rect):
+        rects.append(rect)
+        return pygame.Surface((10, 10))
+
+    renderer.explosion_sheet.subsurface = fake_sub
+    renderer.draw_explosion(env, (0, 0))
+    assert rects[-1][0] == 0
+
+    env.crash_timer = 0.0
+    renderer.draw_explosion(env, (0, 0))
+    assert rects[-1][0] == 150

--- a/tests/test_hud_score.py
+++ b/tests/test_hud_score.py
@@ -1,0 +1,28 @@
+import pytest  # noqa: F401
+from super_pole_position.envs.pole_position import PolePositionEnv  # noqa: E402
+from super_pole_position.ui.arcade import ArcadeRenderer  # noqa: E402
+
+pygame = pytest.importorskip("pygame")
+
+
+def test_score_hiscore_update(monkeypatch):
+    screen = pygame.Surface((320, 240))
+    env = PolePositionEnv(render_mode="human")
+    env.reset()
+    env.high_score = 200
+    env.score = 100
+    renderer = ArcadeRenderer(screen)
+
+    texts = []
+
+    def fake_render(text, aa, color):
+        texts.append(text)
+        return pygame.Surface((1, 1))
+
+    renderer.font.render = fake_render
+    renderer.draw(env)
+    assert env.high_score == 200
+    env.score = 250
+    renderer.draw(env)
+    assert env.high_score == 250
+    assert any("HI" in t for t in texts)

--- a/tests/test_hyper_mode.py
+++ b/tests/test_hyper_mode.py
@@ -1,0 +1,16 @@
+import importlib
+import pytest  # noqa: F401
+
+
+def test_hyper_mode_spawns_and_uncaps(monkeypatch, tmp_path):
+    monkeypatch.setenv("HYPER_MODE", "1")
+    module = importlib.import_module("super_pole_position.envs.pole_position")
+    importlib.reload(module)
+    env = module.PolePositionEnv(render_mode="human")
+    env.reset()
+    monkeypatch.setattr(module, "random", lambda: 0.0)
+    start_obstacles = len(env.track.obstacles)
+    env.cars[0].speed = env.cars[0].gear_max[0] + 1
+    env.step({"throttle": True, "brake": False, "steer": 0.0})
+    assert env.cars[0].speed > env.cars[0].gear_max[0]
+    assert len(env.track.obstacles) > start_obstacles

--- a/tests/test_perf_hud.py
+++ b/tests/test_perf_hud.py
@@ -1,13 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-# Copyright (c) 2025 MIND INTERFACES, INC. All rights reserved.
-# Licensed under the MIT License.
-
-"""
-test_hud_render.py
-Description: Test suite for test_hud_render.
-"""
-
 import pytest  # noqa: F401
 from super_pole_position.envs.pole_position import PolePositionEnv  # noqa: E402
 from super_pole_position.ui.arcade import Pseudo3DRenderer  # noqa: E402
@@ -15,11 +5,20 @@ from super_pole_position.ui.arcade import Pseudo3DRenderer  # noqa: E402
 pygame = pytest.importorskip("pygame")
 
 
-def test_hud_render_smoke():
-    pygame.display.init()
-    screen = pygame.display.set_mode((320, 240))
+def test_perf_hud(monkeypatch):
+    screen = pygame.Surface((320, 240))
     env = PolePositionEnv(render_mode="human")
     env.reset()
+    env.latency_ms = 5
+    env.loop_hz = 60
     renderer = Pseudo3DRenderer(screen)
+
+    texts = []
+
+    def fake_render(text, aa, color):
+        texts.append(text)
+        return pygame.Surface((1, 1))
+
+    renderer.font.render = fake_render
     renderer.draw(env)
-    pygame.display.quit()
+    assert any("LAG" in t for t in texts)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,21 @@
+import pytest  # noqa: F401
+
+pygame = pytest.importorskip("pygame")
+from super_pole_position.envs.pole_position import PolePositionEnv  # noqa: E402
+from super_pole_position.ui.arcade import Pseudo3DRenderer  # noqa: E402
+
+
+def test_dynamic_curve_perspective(monkeypatch):
+    screen = pygame.Surface((320, 240))
+    env = PolePositionEnv(render_mode="human")
+    env.reset()
+    renderer = Pseudo3DRenderer(screen)
+
+    monkeypatch.setattr(env.track, "curvature_at", lambda s: 0.0)
+    x1_zero, x2_zero, _ = renderer.draw_road(env)
+
+    monkeypatch.setattr(env.track, "curvature_at", lambda s: 1.0)
+    x1_curve, x2_curve, _ = renderer.draw_road(env)
+
+    assert x1_curve > x1_zero
+    assert x2_curve > x2_zero


### PR DESCRIPTION
## Summary
- adjust pseudo-3D road to use track curvature
- animate explosions with sprite sheet
- show score and hi-score in HUD
- support hyper mode and performance metrics
- log benchmark results as JSON after episodes
- add tests for new rendering features and modes

## Testing
- `ruff check .`
- `pyright .` *(fails: Import "torch" could not be resolved, Import "transformers" could not be resolved, Import "pygame" could not be resolved, Import "numpy" could not be resolved, Import "gymnasium" could not be resolved, Argument type issues, etc.)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'super_pole_position', 'numpy', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684e2dc57c08832488f20dc2e34d1753