### PR TITLE
Add pygame mixer fallback for audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Press **Enter** to begin or **Esc** to quit.
 - 🖥️ Python 3.8+  
 - 🏎️ Gymnasium (Reinforcement Learning framework)  
 - 🧠 PyTorch / TensorFlow (for AI models)  
-- 🎵 SimpleAudio (for binaural effects)
+- 🎵 SimpleAudio (or fallback to Pygame's mixer)
 - 🎮 Pygame (for optional graphics)
 - 📡 ZeroMQ / WebSockets (for live AI telemetry)
 


### PR DESCRIPTION
## Summary
- allow pygame mixer to handle audio when simpleaudio isn't available
- note mixer fallback in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -e .[dev] -q`
- `pytest tests/test_cli_headless.py::test_cli_headless -q`

------
https://chatgpt.com/codex/tasks/task_e_684e373e6e748324a3a0666b69e8f968