### PR TITLE
Add keyboard gameplay controls

### DIFF
--- a/GAMEPLAY_FAQ.md
+++ b/GAMEPLAY_FAQ.md
@@ -1,0 +1,16 @@
+# 🎮 Gameplay FAQ
+
+## How do I drive?
+
+- **Throttle**: Press the **Up Arrow** to accelerate.
+- **Brake**: Press the **Down Arrow** to slow down.
+- **Steer**: Use **Left** and **Right Arrows** to turn.
+- **Shift Gear**: Tap **Z** to shift down and **X** to shift up just like the arcade shifter.
+
+## Tips
+
+- Stay on the road to maintain speed – off-road driving slows you down!
+- Use gentle steering to avoid skids.
+- Finish four laps as fast as possible to top the leaderboard.
+
+Enjoy the ride! 🏁

--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ Press **Enter** to begin or **Esc** to quit.
 🕹️ **CAR 1:** _(Human or AI)_  
 ⬆️ **Throttle**  
 ⬇️ **Brake**  
-⬅️➡️ **Steer Left / Right**  
+⬅️➡️ **Steer Left / Right**
+**Z/X** **Shift Down / Up**
+
+For more details see [GAMEPLAY_FAQ.md](GAMEPLAY_FAQ.md).
 
 🕹️ **CAR 2:** _(AI-Driven)_  
 🤖 **Automated racing, planning, and learning**  

--- a/super_pole_position/agents/__init__.py
+++ b/super_pole_position/agents/__init__.py
@@ -10,3 +10,4 @@ Description: Module for Super Pole Position.
 
 
 """Agent implementations and controller helpers."""
+from .keyboard_agent import KeyboardAgent

--- a/super_pole_position/agents/keyboard_agent.py
+++ b/super_pole_position/agents/keyboard_agent.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+keyboard_agent.py
+Description: Module for Super Pole Position.
+"""
+
+from __future__ import annotations
+
+try:
+    import pygame  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    pygame = None
+
+from .base_llm_agent import BaseLLMAgent
+
+
+class KeyboardAgent(BaseLLMAgent):
+    """Human-controlled agent using the keyboard 🎮."""
+
+    def __init__(self) -> None:
+        self._last_up = False
+        self._last_down = False
+
+    def act(self, observation) -> dict:
+        if pygame is None:
+            return {"throttle": 0, "brake": 0, "steer": 0.0, "gear": 0}
+
+        keys = pygame.key.get_pressed()
+        throttle = int(keys[pygame.K_UP])
+        brake = int(keys[pygame.K_DOWN])
+        steer = 0.0
+        if keys[pygame.K_LEFT]:
+            steer -= 1.0
+        if keys[pygame.K_RIGHT]:
+            steer += 1.0
+
+        gear = 0
+        shift_up = keys[pygame.K_x]
+        shift_down = keys[pygame.K_z]
+        if shift_up and not self._last_up:
+            gear = 1
+        if shift_down and not self._last_down:
+            gear = -1
+        self._last_up = shift_up
+        self._last_down = shift_down
+        return {"throttle": throttle, "brake": brake, "steer": steer, "gear": gear}

--- a/super_pole_position/cli.py
+++ b/super_pole_position/cli.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from .agents.base_llm_agent import NullAgent
 from .agents.openai_agent import OpenAIAgent
 from .agents.mistral_agent import MistralAgent
+from .agents.keyboard_agent import KeyboardAgent
 from .envs.pole_position import PolePositionEnv
 from .matchmaking.arena import run_episode, update_leaderboard
 from .evaluation.metrics import summary
@@ -27,6 +28,7 @@ AGENT_MAP = {
     "null": NullAgent,
     "openai": OpenAIAgent,
     "mistral": MistralAgent,
+    "keyboard": KeyboardAgent,
 }
 
 

--- a/super_pole_position/matchmaking/arena.py
+++ b/super_pole_position/matchmaking/arena.py
@@ -24,9 +24,13 @@ def run_episode(
 ) -> float:
     """Run one episode and return cumulative reward for agent 0."""
     obs, _ = env.reset()
+    if env.render_mode == "human":
+        env.render()
     done = False
     total = 0.0
     while not done:
+        if env.render_mode == "human":
+            env.render()
         action0 = agents[0].act(obs)
         action0_tuple = (
             action0.get("throttle", 0),
@@ -36,6 +40,8 @@ def run_episode(
         )
         obs, reward, done, _, _ = env.step(action0_tuple)
         total += reward
+        if env.render_mode == "human":
+            env.render()
     env.episode_reward = total
     return total
 


### PR DESCRIPTION
## Summary
- add a keyboard-controlled agent
- render game each frame when human mode is enabled
- update README controls and link to new gameplay FAQ
- provide quick gameplay FAQ

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e5e066ebc8324a1aaf71d2ac97859