### PR TITLE
Add dt-aware physics tick and car state dataclass

### DIFF
--- a/super_pole_position/physics/__init__.py
+++ b/super_pole_position/physics/__init__.py
@@ -13,5 +13,6 @@ Description: Module for Super Pole Position.
 from .car import Car
 from .track import Track
 from .traffic_car import TrafficCar
+from .state import CarState
 
-__all__ = ["Car", "Track", "TrafficCar"]
+__all__ = ["Car", "Track", "TrafficCar", "CarState"]

--- a/super_pole_position/physics/state.py
+++ b/super_pole_position/physics/state.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class CarState:
+    """Simple dataclass for serialising car state."""
+
+    x: float
+    y: float
+    speed: float
+    angle: float
+    lap: int = 0
+    damage: float = 0.0

--- a/super_pole_position/physics/track.py
+++ b/super_pole_position/physics/track.py
@@ -162,6 +162,12 @@ class Track:
         delta = (car.x - self.start_x) % self.width
         return delta / self.width
 
+    def distance_along_track(self, pos) -> float:
+        """Return normalized distance 0..1 along track from ``start_x``."""
+        x = pos.x if hasattr(pos, "x") else pos[0]
+        delta = (x - self.start_x) % self.width
+        return delta / self.width
+
     def in_puddle(self, car) -> bool:
         """Return True if ``car`` is inside a puddle."""
 

--- a/tests/test_carstate.py
+++ b/tests/test_carstate.py
@@ -1,0 +1,16 @@
+from super_pole_position.physics.state import CarState
+from super_pole_position.physics.track import Track
+
+
+def test_carstate_defaults():
+    cs = CarState(x=1.0, y=2.0, speed=3.0, angle=0.5)
+    assert cs.lap == 0
+    assert cs.damage == 0.0
+    assert cs.x == 1.0
+
+
+def test_distance_along_track():
+    track = Track(width=100.0, height=100.0)
+    track.start_x = 10.0
+    d = track.distance_along_track((60.0, 0.0))
+    assert d == 0.5

--- a/tests/test_physics_dt.py
+++ b/tests/test_physics_dt.py
@@ -1,0 +1,20 @@
+from super_pole_position.envs.pole_position import PolePositionEnv
+
+
+class DummyClock:
+    def __init__(self, ms):
+        self.ms = ms
+
+    def get_time(self):
+        return self.ms
+
+
+def test_step_uses_clock_dt():
+    env = PolePositionEnv(render_mode="human")
+    env.clock = DummyClock(500)  # 0.5s
+    env.reset()
+    prev = env.cars[0].speed
+    env.step((True, False, 0.0))
+    assert env.cars[0].speed > prev
+    env.close()
+


### PR DESCRIPTION
## Summary
- implement `CarState` dataclass
- add `distance_along_track` helper for tracks
- compute physics timestep from clock for frame rate independence
- test new physics utilities

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/test_carstate.py tests/test_physics_dt.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e75c983608324981dd0c99091e066