### PR TITLE
Add scoreboard API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,17 @@ super-pole-position --episodes 1
 🏎️ **Rank | AI Name | Best Lap Time**  
 1️⃣ 🔥 **TURBO-GPT** - 1:07.32  
 2️⃣ 🏎️ **VELOCITY-VECTOR** - 1:09.84  
-3️⃣ ⚡ **NEURAL-RACER-X** - 1:11.29  
+3️⃣ ⚡ **NEURAL-RACER-X** - 1:11.29
+
+### Scoreboard API
+
+Start a simple server (requires `fastapi`):
+
+```bash
+python -m super_pole_position.server.api
+```
+
+Use `GET /scores` to list results and `POST /scores` to submit new scores.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,15 @@
+# SUPER POLE POSITION Roadmap
+
+This document highlights planned milestones for upcoming releases.
+
+## v1.0.0
+- Initial release with racing environment and CLI tools.
+- Basic leaderboard and score tracking.
+- Optional scoreboard HTTP API.
+
+## v1.1.0
+- Enhanced telemetry output via WebSockets.
+- Visualization notebooks for replay analysis.
+
+## v2.0.0
+- Community model submissions and tournament mode.

--- a/SCOREBOARD_ENDPOINTS.md
+++ b/SCOREBOARD_ENDPOINTS.md
@@ -1,0 +1,21 @@
+# Scoreboard API
+
+This project exposes a minimal HTTP API for retrieving and submitting
+scores. The API is optional and requires `fastapi` to be installed.
+
+## Start the server
+
+```bash
+python -m super_pole_position.server.api
+```
+
+The server will listen on `127.0.0.1:8000` by default.
+
+## Endpoints
+
+- `GET /scores` – return the current scoreboard as JSON.
+- `POST /scores` – submit a JSON body `{"name": "AI", "score": 123}` to add a
+  new score.
+
+Scores are stored in `scores.json` inside the package directory unless the
+`SPP_SCORES` environment variable points to a different file.

--- a/super_pole_position/server/__init__.py
+++ b/super_pole_position/server/__init__.py
@@ -1,0 +1,5 @@
+"""Server package for Super Pole Position."""
+
+from __future__ import annotations
+
+__all__ = ["api"]

--- a/super_pole_position/server/api.py
+++ b/super_pole_position/server/api.py
@@ -1,0 +1,65 @@
+"""Minimal HTTP API for scoreboards."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from ..evaluation import scores
+
+try:  # pragma: no cover - optional dependency
+    from fastapi import FastAPI, HTTPException
+    from fastapi.responses import JSONResponse
+    from pydantic import BaseModel
+except Exception:  # pragma: no cover - fastapi missing
+    FastAPI = None
+    BaseModel = object  # type: ignore
+    HTTPException = Exception
+    JSONResponse = dict  # type: ignore
+
+
+class ScoreIn(BaseModel):
+    """Score entry model."""
+
+    name: str
+    score: int
+
+
+SCORES_FILE = Path(os.getenv("SPP_SCORES", scores._DEFAULT_FILE))
+
+
+def build_app() -> "FastAPI":
+    """Return a FastAPI app serving the scoreboard."""
+
+    if FastAPI is None:
+        raise RuntimeError("fastapi not available")
+
+    app = FastAPI(title="SPP Scoreboard")
+
+    @app.get("/scores")
+    def get_scores() -> Any:
+        return {"scores": scores.load_scores(SCORES_FILE)}
+
+    from fastapi import Body
+
+    @app.post("/scores")
+    def post_score(entry: ScoreIn = Body(...)) -> Any:
+        try:
+            scores.update_scores(SCORES_FILE, entry.name, entry.score)
+        except Exception as exc:  # pragma: no cover - file error
+            raise HTTPException(status_code=500, detail=str(exc))
+        return JSONResponse({"ok": True})
+
+    return app
+
+
+def start(host: str = "127.0.0.1", port: int = 8000) -> None:
+    """Start the API server if FastAPI is available."""
+
+    if FastAPI is None:
+        print("FastAPI not installed", flush=True)
+        return
+    import uvicorn  # pragma: no cover - runtime import
+
+    uvicorn.run(build_app(), host=host, port=port)

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Test scoreboard API."""
+
+import os
+import sys
+from pathlib import Path
+
+import importlib
+import pytest
+
+BASE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BASE))
+
+skip_if_no_fastapi = pytest.mark.skipif(
+    importlib.util.find_spec("fastapi") is None,
+    reason="fastapi not installed",
+)
+
+
+@skip_if_no_fastapi
+def test_scores_endpoints(tmp_path: Path) -> None:
+    scores_path = tmp_path / "scores.json"
+    os.environ["SPP_SCORES"] = str(scores_path)
+    from super_pole_position.server import api
+    import importlib
+    importlib.reload(api)
+    app = api.build_app()
+    from fastapi.testclient import TestClient
+
+    client = TestClient(app)
+    resp = client.get("/scores")
+    assert resp.status_code == 200
+    assert resp.json() == {"scores": []}
+
+    resp = client.post("/scores", json={"name": "bot", "score": 5})
+    assert resp.status_code == 200
+
+    resp = client.get("/scores")
+    data = resp.json()
+    assert any(entry["name"] == "bot" for entry in data["scores"])


### PR DESCRIPTION
## Summary
- add optional FastAPI server for posting and reading scores
- document API usage and add project roadmap
- include simple test for the new endpoints

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/test_api_server.py -q`
- `flake8 super_pole_position/server/api.py tests/test_api_server.py`


------
https://chatgpt.com/codex/tasks/task_e_684e75c983608324981dd0c99091e066