### PR TITLE
Improve scanline effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Arcade Parity Improvements
+- Parameterized scanline effect intensity via `config.arcade_parity.yaml`.
+- Reduced default scanline darkness for a softer CRT vibe.

--- a/config.arcade_parity.yaml
+++ b/config.arcade_parity.yaml
@@ -1,0 +1,2 @@
+scanline_step: 2
+scanline_alpha: 64

--- a/super_pole_position/ui/arcade.py
+++ b/super_pole_position/ui/arcade.py
@@ -12,6 +12,7 @@ Description: Module for Super Pole Position.
 
 import os
 from pathlib import Path
+from typing import Dict
 
 from .sprites import BILLBOARD_ART, CAR_ART, EXPLOSION_FRAMES, ascii_surface
 from ..evaluation.scores import load_scores
@@ -25,6 +26,22 @@ try:
     import pygame  # type: ignore
 except Exception:  # pragma: no cover
     pygame = None
+
+
+def _load_arcade_config() -> Dict[str, int]:
+    """Return scanline configuration from ``config.arcade_parity.yaml``."""
+
+    cfg = {"scanline_step": 2, "scanline_alpha": 255}
+    path = Path(__file__).resolve().parents[2] / "config.arcade_parity.yaml"
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                if ":" in line:
+                    key, val = line.split(":", 1)
+                    cfg[key.strip()] = int(val.strip())
+    except Exception:
+        pass
+    return cfg
 
 
 class Palette:
@@ -177,6 +194,14 @@ class Pseudo3DRenderer:
         self.car_sprite = ascii_surface(CAR_ART)
         self.billboard_sprite = ascii_surface(BILLBOARD_ART)
         self.explosion_frames = [ascii_surface(f) for f in EXPLOSION_FRAMES]
+        cfg = _load_arcade_config()
+        self.scanline_step = cfg["scanline_step"]
+        self.scanline_alpha = cfg["scanline_alpha"]
+        if pygame:
+            self._scanline_row = pygame.Surface((1, 1), pygame.SRCALPHA)
+            self._scanline_row.fill((0, 0, 0, self.scanline_alpha))
+        else:
+            self._scanline_row = None
 
     def road_polygon(self, offset: float) -> list[tuple[float, float]]:
         """Return trapezoid points for the road given ``offset``."""
@@ -367,5 +392,7 @@ class Pseudo3DRenderer:
             pygame.draw.circle(self.screen, (0, 255, 0), (int(ox), int(oy)), 3)
 
         # Scanline effect
-        for y in range(0, height, 2):
-            pygame.draw.line(self.screen, (0, 0, 0), (0, y), (width, y), 1)
+        if self._scanline_row:
+            row = pygame.transform.scale(self._scanline_row, (width, 1))
+            for y in range(0, height, self.scanline_step):
+                self.screen.blit(row, (0, y))

--- a/tests/baseline.txt
+++ b/tests/baseline.txt
@@ -1,0 +1,1 @@
+scanline_alpha: 255

--- a/tests/test_arcade_parity.py
+++ b/tests/test_arcade_parity.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+test_arcade_parity.py
+Description: Benchmark scanline effect intensity.
+"""
+
+from pathlib import Path
+
+import pytest  # noqa: F401
+
+from super_pole_position.ui import arcade
+
+
+def _read_baseline() -> int:
+    base = Path(__file__).resolve().parent / "baseline.txt"
+    for line in base.read_text().splitlines():
+        if "scanline_alpha" in line:
+            return int(line.split(":", 1)[1].strip())
+    return 255
+
+
+def test_scanline_intensity_improved():
+    baseline = _read_baseline()
+    cfg = arcade._load_arcade_config()
+    assert cfg["scanline_alpha"] <= baseline - 10
+


### PR DESCRIPTION
## Summary
- add `config.arcade_parity.yaml` for scanline tweakage
- load config in renderer and use semi-transparent scanline overlay
- document change in CHANGELOG
- test scanline config against baseline

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/test_arcade_parity.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684e793843008324a9b14a8798d2c5ab