### PR TITLE
Arcade parity tweak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 benchmarks/*
 !benchmarks/README.md
+!benchmarks/baseline_puddle.txt
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Arcade Parity Improvements
+- Adjust puddle traction slowdown to 0.65 for stickier puddles.

--- a/benchmarks/baseline_puddle.txt
+++ b/benchmarks/baseline_puddle.txt
@@ -1,0 +1,1 @@
+baseline_ratio 0.7

--- a/config.arcade_parity.yaml
+++ b/config.arcade_parity.yaml
@@ -1,0 +1,4 @@
+# Arcade parity tuning parameters
+puddle:
+  speed_factor: 0.65
+  angle_jitter: 0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ authors = [{name="System Operators"}]
 requires-python = ">=3.8"
 dependencies = [
     "gymnasium",
-    "numpy"
+    "numpy",
+    "pyyaml"
 ]
 
 [project.optional-dependencies]

--- a/super_pole_position/config.py
+++ b/super_pole_position/config.py
@@ -1,0 +1,34 @@
+"""Configuration utilities for arcade parity tweaks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - PyYAML optional
+    yaml = None
+
+DEFAULTS = {
+    "puddle": {"speed_factor": 0.65, "angle_jitter": 0.2}
+}
+
+CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.arcade_parity.yaml"
+
+
+def load_parity_config() -> dict[str, Any]:
+    """Return arcade parity parameters from YAML or defaults."""
+    data: dict[str, Any] = {}
+    if yaml and CONFIG_PATH.exists():
+        try:
+            with CONFIG_PATH.open() as fh:
+                loaded = yaml.safe_load(fh)
+                if isinstance(loaded, dict):
+                    data = loaded
+        except Exception:
+            data = {}
+    cfg = DEFAULTS | data
+    if "puddle" in data:
+        cfg["puddle"] = DEFAULTS["puddle"] | data.get("puddle", {})
+    return cfg

--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -30,8 +30,10 @@ from ..physics.track import Track
 from ..physics.traffic_car import TrafficCar
 from ..agents.controllers import GPTPlanner, LowLevelController, LearningAgent
 from ..ui.arcade import Pseudo3DRenderer
+from ..config import load_parity_config
 
 FAST_TEST = bool(int(os.getenv("FAST_TEST", "0")))
+PARITY_CFG = load_parity_config()
 
 
 class PolePositionEnv(gym.Env):
@@ -415,8 +417,10 @@ class PolePositionEnv(gym.Env):
             self.offroad_frames += 1
 
         if self.track.in_puddle(self.cars[0]):
-            self.cars[0].speed *= 0.7
-            self.cars[0].angle += np.random.uniform(-0.2, 0.2)
+            factor = PARITY_CFG["puddle"].get("speed_factor", 0.7)
+            jitter = PARITY_CFG["puddle"].get("angle_jitter", 0.2)
+            self.cars[0].speed *= factor
+            self.cars[0].angle += np.random.uniform(-jitter, jitter)
 
         if self.track.billboard_hit(self.cars[0]):
             self.remaining_time = max(self.remaining_time - 5.0, 0.0)

--- a/tests/test_arcade_parity.py
+++ b/tests/test_arcade_parity.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from super_pole_position.envs.pole_position import PolePositionEnv
+from super_pole_position.physics.track import Track, Puddle
+
+
+def measure_puddle_ratio() -> float:
+    env = PolePositionEnv(render_mode="human")
+    env.track = Track(width=200.0, height=200.0, puddles=[Puddle(x=50, y=50, radius=10)])
+    env.reset()
+    env.step({"throttle": True, "brake": False, "steer": 0.0})
+    pre = env.cars[0].speed
+    env.step({"throttle": False, "brake": False, "steer": 0.0})
+    post = env.cars[0].speed
+    return post / pre
+
+
+def test_puddle_slowdown_improved():
+    with open("benchmarks/baseline_puddle.txt") as fh:
+        baseline_ratio = float(fh.read().split()[1])
+    ratio = measure_puddle_ratio()
+    assert ratio < baseline_ratio - 0.04


### PR DESCRIPTION
## Summary
- load arcade parity config via YAML
- tweak puddle slowdown via config
- track baseline slowdown value
- test slowdown improvement
- document arcade parity improvement

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/test_arcade_parity.py`

------
https://chatgpt.com/codex/tasks/task_e_684e793843008324a9b14a8798d2c5ab