### PR TITLE
Add quick startup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ rrrrr
 ## Quick Start
 ```bash
 pip install -e .[dev]
+python press_start.py
+# or dive into the CLI
 spp qualify --agent null --track fuji
 ```
 ![](docs.gif)

--- a/press_start.py
+++ b/press_start.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Launch the game with one press. 🕹️"""
+
+from __future__ import annotations
+
+from super_pole_position.agents.keyboard_agent import KeyboardAgent
+from super_pole_position.envs.pole_position import PolePositionEnv
+from super_pole_position.evaluation.metrics import summary
+from super_pole_position.matchmaking.arena import run_episode
+
+
+INTRO = """
+ rrr
+rrrrr
+ rrr
+"""
+
+
+def main() -> None:
+    """Show a tiny intro and jump into the race."""
+
+    print("🏎️ SUPER-POLE-POSITION 🏁")
+    print(INTRO)
+    input("Press Enter to start!")
+    env = PolePositionEnv(render_mode="human", mode="race", track_name="fuji")
+    agent = KeyboardAgent()
+    run_episode(env, (agent, agent))
+    print(summary(env))
+    env.close()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    main()


### PR DESCRIPTION
## Summary
- add `press_start.py` for one-click game launch
- mention the script in the Quick Start instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684e912a812c8324853b2e9f8027821b