### PR TITLE
Add playful emoji comments to launcher

### DIFF
--- a/press_start.py
+++ b/press_start.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Launch the game with one press. 🕹️"""
+"""Launch the game with one press. 🕹️🚦
+
+Tiny script for a quick retro blast.
+"""
 
 from __future__ import annotations
 
@@ -13,6 +16,7 @@ INTRO = """
  rrr
 rrrrr
  rrr
+🚥  READY?
 """
 
 
@@ -22,10 +26,14 @@ def main() -> None:
     print("🏎️ SUPER-POLE-POSITION 🏁")
     print(INTRO)
     input("Press Enter to start!")
+    # 🚗 Prepare the track and cars
     env = PolePositionEnv(render_mode="human", mode="race", track_name="fuji")
     agent = KeyboardAgent()
+    # 🔁 One quick lap with two identical agents
     run_episode(env, (agent, agent))
+    # 📊 Display a tiny summary
     print(summary(env))
+    print("🎉 Thanks for playing!")
     env.close()
 
 

--- a/super_pole_position/agents/keyboard_agent.py
+++ b/super_pole_position/agents/keyboard_agent.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-keyboard_agent.py
-Description: Module for Super Pole Position.
-"""
+"""Keyboard controls for your retro racer. 🎹"""
 
 from __future__ import annotations
 
@@ -26,18 +23,19 @@ class KeyboardAgent(BaseLLMAgent):
         if pygame is None:
             return {"throttle": 0, "brake": 0, "steer": 0.0, "gear": 0}
 
+        # 🎮 Capture current key states
         keys = pygame.key.get_pressed()
-        throttle = int(keys[pygame.K_UP])
-        brake = int(keys[pygame.K_DOWN])
+        throttle = int(keys[pygame.K_UP])  # ⬆️ accelerate
+        brake = int(keys[pygame.K_DOWN])  # ⬇️ slow down
         steer = 0.0
-        if keys[pygame.K_LEFT]:
+        if keys[pygame.K_LEFT]:  # ⬅️ turn left
             steer -= 1.0
-        if keys[pygame.K_RIGHT]:
+        if keys[pygame.K_RIGHT]:  # ➡️ turn right
             steer += 1.0
 
         gear = 0
-        shift_up = keys[pygame.K_x]
-        shift_down = keys[pygame.K_z]
+        shift_up = keys[pygame.K_x]  # X to shift up
+        shift_down = keys[pygame.K_z]  # Z to shift down
         if shift_up and not self._last_up:
             gear = 1
         if shift_down and not self._last_down:


### PR DESCRIPTION
## Summary
- sprinkle retro emojis and comments in `press_start.py`
- add cute inline explanations in `keyboard_agent.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684eb31e0a1083248f74f2b462a7af5f