### PR TITLE
Ensure graphics config loads properly

### DIFF
--- a/super_pole_position/ui/arcade.py
+++ b/super_pole_position/ui/arcade.py
@@ -77,9 +77,14 @@ def _load_arcade_config() -> Dict[str, int]:
     try:
         with open(path, "r", encoding="utf-8") as fh:
             for line in fh:
-                if ":" in line:
-                    key, val = line.split(":", 1)
+                if ":" not in line:
+                    continue
+                key, val = line.split(":", 1)
+                try:
                     cfg[key.strip()] = int(val.strip())
+                except Exception:
+                    # Ignore non-numeric values and keep defaults
+                    continue
     except Exception:
         pass
     return cfg


### PR DESCRIPTION
## Summary
- handle non-numeric values when loading arcade config

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eb60459fc8324b4d32f71b6a8df5a