### PR TITLE
Improve pygame initialization

### DIFF
--- a/super_pole_position/__init__.py
+++ b/super_pole_position/__init__.py
@@ -8,6 +8,12 @@ __init__.py
 Description: Module for Super Pole Position.
 """
 
+import os
+
+# Ensure pygame can initialise even without a display
+if os.name != "nt" and "DISPLAY" not in os.environ:
+    os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
 
 
 from .physics.car import Car

--- a/super_pole_position/cli.py
+++ b/super_pole_position/cli.py
@@ -65,6 +65,8 @@ def main() -> None:
 
     if args.cmd == "qualify":
         if args.render:
+            if os.name != "nt" and "DISPLAY" not in os.environ:
+                os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
             try:
                 import pygame
                 from .ui import menu
@@ -104,6 +106,8 @@ def main() -> None:
         print(metrics)
     else:
         if args.render:
+            if os.name != "nt" and "DISPLAY" not in os.environ:
+                os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
             try:
                 import pygame
                 from .ui import menu

--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -616,10 +616,25 @@ class PolePositionEnv(gym.Env):
                 self.clock = pygame.time.Clock()
                 self.renderer = Pseudo3DRenderer(self.screen)
             except Exception as exc:  # pragma: no cover - init error
-                print(f"pygame init failed: {exc}", flush=True)
-                self.screen = None
-                pygame = None
-                return
+                if os.name != "nt" and "DISPLAY" not in os.environ:
+                    os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+                    try:
+                        pygame.init()
+                        size = (640, 480)
+                        self.screen = pygame.display.set_mode(size)
+                        pygame.display.set_caption("Super Pole Position")
+                        self.clock = pygame.time.Clock()
+                        self.renderer = Pseudo3DRenderer(self.screen)
+                    except Exception as exc2:
+                        print(f"pygame init failed: {exc2}", flush=True)
+                        self.screen = None
+                        pygame = None
+                        return
+                else:
+                    print(f"pygame init failed: {exc}", flush=True)
+                    self.screen = None
+                    pygame = None
+                    return
 
         try:
             for event in pygame.event.get():


### PR DESCRIPTION
## Summary
- set `SDL_VIDEODRIVER` fallback when importing the package
- ensure CLI sets the dummy video driver if no display is found
- retry pygame init with dummy driver in the environment renderer

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68556e6b49548324b60c187b8d008c26