### PR TITLE
Suppress pygame support prompt

### DIFF
--- a/super_pole_position/__init__.py
+++ b/super_pole_position/__init__.py
@@ -10,6 +10,9 @@ Description: Module for Super Pole Position.
 
 import os
 
+# Hide pygame's greeting for cleaner logs
+os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
+
 # Ensure pygame can initialise even without a display
 if os.name != "nt" and "DISPLAY" not in os.environ:
     os.environ.setdefault("SDL_VIDEODRIVER", "dummy")

--- a/super_pole_position/agents/keyboard_agent.py
+++ b/super_pole_position/agents/keyboard_agent.py
@@ -4,6 +4,11 @@
 
 from __future__ import annotations
 
+import os
+
+# Hide pygame's greeting for cleaner logs
+os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
+
 try:
     import pygame  # type: ignore
 except Exception:  # pragma: no cover - optional dependency

--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -10,6 +10,9 @@ Description: Module for Super Pole Position.
 """
 
 import os
+
+# Hide pygame's greeting for cleaner logs
+os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
 import numpy as np
 import gymnasium as gym
 import time

--- a/super_pole_position/ui/arcade.py
+++ b/super_pole_position/ui/arcade.py
@@ -11,6 +11,9 @@ Description: Module for Super Pole Position.
 
 
 import os
+
+# Hide pygame's greeting for cleaner logs
+os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
 from pathlib import Path
 from typing import Dict
 

--- a/super_pole_position/ui/menu.py
+++ b/super_pole_position/ui/menu.py
@@ -13,6 +13,9 @@ Description: Module for Super Pole Position.
 from __future__ import annotations
 
 import os
+
+# Hide pygame's greeting for cleaner logs
+os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
 import random
 from pathlib import Path
 

--- a/super_pole_position/ui/sprites.py
+++ b/super_pole_position/ui/sprites.py
@@ -8,6 +8,12 @@ sprites.py
 Description: Module for Super Pole Position.
 """
 
+import os
+
+# Hide pygame's greeting for cleaner logs
+os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
+
+
 
 try:
     import pygame  # type: ignore


### PR DESCRIPTION
## Summary
- hide pygame welcome prompt for smoother init

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6855726c987883248f5c475c9d8f6af2