### PR TITLE
Fix audio array contiguity

### DIFF
--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -716,7 +716,7 @@ class PolePositionEnv(gym.Env):
 
         waveform = np.vstack((left, right)).T
         waveform = np.clip(waveform, -1.0, 1.0)
-        waveform_int16 = np.int16(waveform * 32767)
+        waveform_int16 = np.ascontiguousarray(waveform * 32767, dtype=np.int16)
 
         if self.audio_stream is not None:
             try:
@@ -856,7 +856,7 @@ class PolePositionEnv(gym.Env):
         left = 0.3 * noise * (1.0 - max(0.0, pan))
         right = 0.3 * noise * (1.0 + min(0.0, pan))
         waveform = np.vstack((left, right)).T
-        waveform_int16 = np.int16(waveform * 32767)
+        waveform_int16 = np.ascontiguousarray(waveform * 32767, dtype=np.int16)
         if self.audio_stream is not None:
             try:
                 self.audio_stream.stop()

--- a/tests/test_audio_triggers.py
+++ b/tests/test_audio_triggers.py
@@ -17,3 +17,11 @@ def test_prepare_voice_on_reset():
     env = PolePositionEnv(render_mode="human")
     env.reset()
     assert env.start_phase == "READY"
+
+
+def test_step_with_audio_no_exception():
+    env = PolePositionEnv(render_mode="human")
+    env.reset()
+    env.cars[0].speed = 6.0
+    env.step((True, False, 1.0))
+    env.close()


### PR DESCRIPTION
## Summary
- ensure audio buffers are contiguous before playback
- cover audio step behavior with new regression test

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68563c4fc6dc8324859387a1124e508d