### PR TITLE
Log lap times to scoreboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Engine pitch factor configurable via `config.arcade_parity.yaml`; default increased for more authentic rev sound.
 - Parameterized scanline effect intensity via `config.arcade_parity.yaml`.
 - Reduced default scanline darkness for a softer CRT vibe.
+- Lap times now sent to the scoreboard API at each lap and race end.

--- a/PROGRESS_ARCADE_PARITY.md
+++ b/PROGRESS_ARCADE_PARITY.md
@@ -18,3 +18,4 @@
 - [x] Cabinet-style color palette & scanline effect
 - [x] Test suite for each new feature
 - [x] Stereo engine audio panned by car position
+- [x] Lap times posted to scoreboard API

--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -37,6 +37,7 @@ from ..ui.arcade import Pseudo3DRenderer
 
 from ..config import load_parity_config
 from ..config import load_arcade_parity
+from ..evaluation import submit_score_http
 
 _PARITY_CONFIG = load_arcade_parity()
 ENGINE_BASE_FREQ = _PARITY_CONFIG.get("engine_base_freq", 400.0)
@@ -533,6 +534,10 @@ class PolePositionEnv(gym.Env):
             self.lap_flash = 2.0
             self.remaining_time += 30.0
             print(f"[ENV] Completed lap {self.lap} in {self.last_lap_time:.2f}s", flush=True)
+            try:
+                submit_score_http("lap", int(self.last_lap_time * 1000))
+            except Exception:
+                pass
             if self.mode == "qualify":
                 self.grid_order = sorted(
                     range(len(self.cars)),
@@ -594,6 +599,10 @@ class PolePositionEnv(gym.Env):
             except Exception:
                 pass
             self.score += int(self.remaining_time * 5)
+            try:
+                submit_score_http("final", int(self.score))
+            except Exception:
+                pass
             print("[ENV] Race finished", flush=True)
 
         experience = (prev_obs, action, reward, self._get_obs())

--- a/super_pole_position/evaluation/__init__.py
+++ b/super_pole_position/evaluation/__init__.py
@@ -11,6 +11,18 @@ Description: Module for Super Pole Position.
 
 
 from .metrics import summary, lap_time
-from .scores import load_scores, update_scores, reset_scores
+from .scores import (
+    load_scores,
+    update_scores,
+    reset_scores,
+    submit_score_http,
+)
 
-__all__ = ["summary", "lap_time", "load_scores", "update_scores", "reset_scores"]
+__all__ = [
+    "summary",
+    "lap_time",
+    "load_scores",
+    "update_scores",
+    "reset_scores",
+    "submit_score_http",
+]

--- a/super_pole_position/evaluation/scores.py
+++ b/super_pole_position/evaluation/scores.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import List, Dict
+from urllib import request
 
 
 _DEFAULT_FILE = Path(__file__).resolve().parent / "scores.json"
@@ -53,3 +54,22 @@ def reset_scores(file: Path | None = None) -> None:
         file.write_text(json.dumps({"scores": []}, indent=2))
     except Exception as exc:  # pragma: no cover - file error
         print(f"reset_scores error: {exc}", flush=True)
+
+
+def submit_score_http(
+    name: str, score: int, host: str = "127.0.0.1", port: int = 8000
+) -> bool:
+    """POST ``score`` for ``name`` to the scoreboard server.
+
+    Returns ``True`` on success.
+    """
+
+    url = f"http://{host}:{port}/scores"
+    data = json.dumps({"name": name, "score": int(score)}).encode()
+    req = request.Request(url, data=data, headers={"Content-Type": "application/json"})
+    try:
+        with request.urlopen(req, timeout=1) as resp:  # pragma: no cover - network
+            return 200 <= resp.status < 300
+    except Exception as exc:  # pragma: no cover - network failure
+        print(f"submit_score_http error: {exc}", flush=True)
+        return False


### PR DESCRIPTION
## Summary
- post score entries via HTTP
- expose new utility in evaluation package
- log lap and final scores from environment
- document scoreboard logging progress

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_68564859791c832493873f713f47e4ac