### PR TITLE
Align default resolution with arcade hardware

### DIFF
--- a/super_pole_position/cli.py
+++ b/super_pole_position/cli.py
@@ -76,7 +76,7 @@ def main() -> None:
                 raise SystemExit(1)
 
             pygame.init()
-            screen = pygame.display.set_mode((640, 480))
+            screen = pygame.display.set_mode((256, 224))
             try:
                 cfg = menu.main_loop(screen)
             except Exception:
@@ -117,7 +117,7 @@ def main() -> None:
                 raise SystemExit(1)
 
             pygame.init()
-            screen = pygame.display.set_mode((640, 480))
+            screen = pygame.display.set_mode((256, 224))
             try:
                 cfg = menu.main_loop(screen)
             except Exception:

--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -620,7 +620,7 @@ class PolePositionEnv(gym.Env):
         if self.screen is None:
             try:
                 pygame.init()
-                size = (640, 480)
+                size = (256, 224)
                 self.screen = pygame.display.set_mode(size)
                 pygame.display.set_caption("Super Pole Position")
                 self.clock = pygame.time.Clock()
@@ -630,7 +630,7 @@ class PolePositionEnv(gym.Env):
                     os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
                     try:
                         pygame.init()
-                        size = (640, 480)
+                        size = (256, 224)
                         self.screen = pygame.display.set_mode(size)
                         pygame.display.set_caption("Super Pole Position")
                         self.clock = pygame.time.Clock()


### PR DESCRIPTION
## Summary
- keep the default window size at 256x224 to match the original arcade resolution

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68564859791c832493873f713f47e4ac