### PR TITLE
Add curved track support

### DIFF
--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -276,14 +276,14 @@ class PolePositionEnv(gym.Env):
 
         # Reset cars to start positions
         self.cars[0].x = 50.0
-        self.cars[0].y = 50.0
+        self.cars[0].y = self.track.y_at(self.cars[0].x)
         self.cars[0].angle = 0.0
         self.cars[0].speed = 0.0
         self.track.start_x = self.cars[0].x
         self.safe_point = (self.cars[0].x, self.cars[0].y)
 
         self.cars[1].x = 150.0
-        self.cars[1].y = 150.0
+        self.cars[1].y = self.track.y_at(self.cars[1].x)
         self.cars[1].angle = 0.0
         self.cars[1].speed = 0.0
 
@@ -446,7 +446,8 @@ class PolePositionEnv(gym.Env):
             self.track.wrap_position(c)
 
         # Off-road slowdown near track edges
-        offroad = self.cars[0].y < 5 or self.cars[0].y > self.track.height - 5
+        center_y = self.track.y_at(self.cars[0].x)
+        offroad = abs(self.cars[0].y - center_y) > self.track.height / 2 - 5
         if offroad:
             self.cars[0].speed *= 0.5
             self.offroad_frames += 1

--- a/super_pole_position/physics/traffic_car.py
+++ b/super_pole_position/physics/traffic_car.py
@@ -27,7 +27,7 @@ class TrafficCar(Car):
 
         steer = 0.0
         if track is not None:
-            target_y = track.height / 2
+            target_y = track.y_at(self.x)
             offset = target_y - self.y
             steer = max(-1.0, min(1.0, offset * 0.1))
 

--- a/super_pole_position/ui/arcade.py
+++ b/super_pole_position/ui/arcade.py
@@ -11,6 +11,7 @@ Description: Module for Super Pole Position.
 
 
 import os
+import math
 
 # Hide pygame's greeting for cleaner logs
 os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
@@ -274,8 +275,8 @@ class Pseudo3DRenderer:
     def draw_road_polygon(self, env) -> list[tuple[float, float]]:
         """Draw the road trapezoid and return its points."""
 
-        curvature = getattr(env.cars[0], "steering", env.cars[0].angle)
-        curvature = max(-1.0, min(curvature, 1.0))
+        angle = env.track.angle_at(env.cars[0].x)
+        curvature = max(-1.0, min(angle / (math.pi / 4), 1.0))
         offset = curvature * (self.screen.get_width() / 4)
         points = self.road_polygon(offset)
         if pygame:
@@ -303,8 +304,8 @@ class Pseudo3DRenderer:
         road_w = width * 0.6
         bottom = height
         player = env.cars[0]
-        curvature = getattr(player, "steering", player.angle)
-        curvature = max(-1.0, min(curvature, 1.0))
+        angle = env.track.angle_at(player.x)
+        curvature = max(-1.0, min(angle / (math.pi / 4), 1.0))
         offset = curvature * (width / 4)
         self.horizon = int(self.horizon_base + offset * 0.1)
 


### PR DESCRIPTION
## Summary
- support segments when loading tracks and provide helper functions
- follow centerline in `TrafficCar.policy`
- derive off-road logic from track segments
- curve the road in the pseudo-3D renderer

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68564f6e1ec48324897750c079890b4c