### PR TITLE
Improve crash penalties and HUD message

### DIFF
--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -172,6 +172,8 @@ class PolePositionEnv(gym.Env):
         self.lap_flash = 0.0
         self.lap_times: list[float] = []
         self.grid_order: list[int] = []
+        self.game_message = ""
+        self.message_timer = 0.0
 
         # Performance metrics
         self.plan_durations: list[float] = []
@@ -273,6 +275,8 @@ class PolePositionEnv(gym.Env):
         self.lap_flash = 0.0
         self.lap_times = []
         self.grid_order = []
+        self.game_message = ""
+        self.message_timer = 0.0
 
         # Reset cars to start positions
         self.cars[0].x = 50.0
@@ -358,6 +362,8 @@ class PolePositionEnv(gym.Env):
             else:
                 self.start_phase = "GO"
                 print("[ENV] GO!", flush=True)
+        if self.message_timer > 0:
+            self.message_timer -= 1.0
 
         # ---- Car 0 (Player / Random) ----
         throttle, brake, steer, gear_cmd = False, False, 0.0, 0
@@ -444,6 +450,11 @@ class PolePositionEnv(gym.Env):
         # Wrap positions on the track
         for c in self.cars:
             self.track.wrap_position(c)
+        if self.cars[0].y < 0.0 or self.cars[0].y > self.track.height:
+            if self.crash_timer <= 0:
+                self.crashes += 1
+                self.crash_timer = 2.5
+                self.cars[0].crash()
 
         # Off-road slowdown near track edges
         center_y = self.track.y_at(self.cars[0].x)
@@ -461,6 +472,10 @@ class PolePositionEnv(gym.Env):
         if self.track.billboard_hit(self.cars[0]):
             self.remaining_time = max(self.remaining_time - 5.0, 0.0)
             self._play_crash_audio()
+            if self.crash_timer <= 0:
+                self.crashes += 1
+                self.crash_timer = 2.5
+                self.cars[0].crash()
 
         # Slip-angle skid penalty
         if abs(steer) > 0.7 and self.cars[0].speed > 5:
@@ -549,9 +564,7 @@ class PolePositionEnv(gym.Env):
             if self.lap == 3:
                 self._play_final_lap_voice()
         if self.mode == "race":
-            while progress >= self.next_checkpoint:
-                self.remaining_time += 30.0
-                self.next_checkpoint += 0.25
+            pass
         self.prev_progress = progress
         self.prev_x = self.cars[0].x
         self.prev_y = self.cars[0].y
@@ -575,7 +588,13 @@ class PolePositionEnv(gym.Env):
         if self.mode == "race" and self.lap >= 4:
             done = True
             self._play_goal_voice()
-        done = done or self.remaining_time <= 0 or (self.current_step >= self.max_steps)
+            self.game_message = "FINISHED!"
+            self.message_timer = 90.0
+        if self.remaining_time <= 0:
+            done = True
+            self.game_message = "TIME UP!"
+            self.message_timer = 90.0
+        done = done or (self.current_step >= self.max_steps)
 
         # Record per-step metrics
         self.step_log.append(

--- a/super_pole_position/physics/track.py
+++ b/super_pole_position/physics/track.py
@@ -180,20 +180,13 @@ class Track:
                 )
         raise FileNotFoundError(name)
 
-    def wrap_position(self, car):
-        """
-        Wraps the car's position if it goes beyond track boundaries.
-        This simulates a toroidal environment (like Pac-Man).
-        """
+    def wrap_position(self, car) -> None:
+        """Wrap ``car.x`` around track width while leaving ``y`` unclamped."""
+
         if car.x < 0.0:
             car.x += self.width
         elif car.x >= self.width:
             car.x -= self.width
-
-        if car.y < 0.0:
-            car.y += self.height
-        elif car.y >= self.height:
-            car.y -= self.height
 
     def distance(self, car1, car2):
         """
@@ -203,9 +196,7 @@ class Track:
         dx = abs(car1.x - car2.x)
         dy = abs(car1.y - car2.y)
 
-        # On a torus, distance wraps around
         dx = min(dx, self.width - dx)
-        dy = min(dy, self.height - dy)
 
         return math.sqrt(dx * dx + dy * dy)
 

--- a/super_pole_position/ui/arcade.py
+++ b/super_pole_position/ui/arcade.py
@@ -470,6 +470,11 @@ class Pseudo3DRenderer:
                 tx = width // 2 - text.get_width() // 2
                 ty = height // 2 - text.get_height() // 2
                 self.screen.blit(text, (tx, ty))
+        if self.start_font and env.message_timer > 0 and env.game_message:
+            msg = self.start_font.render(env.game_message, True, (255, 255, 0))
+            mx = width // 2 - msg.get_width() // 2
+            my = height // 2 - msg.get_height() // 2
+            self.screen.blit(msg, (mx, my))
 
         # Scanline effect
 

--- a/tests/test_billboard_collision.py
+++ b/tests/test_billboard_collision.py
@@ -23,5 +23,6 @@ def test_billboard_collision_time_bleed():
     before = env.remaining_time
     env.step((True, False, 0.0))
     assert env.remaining_time < before
+    assert env.crash_timer > 0
     assert not env.track.obstacles
     env.close()

--- a/tests/test_timer_checkpoint.py
+++ b/tests/test_timer_checkpoint.py
@@ -23,10 +23,9 @@ def test_checkpoint_timer_rollover():
     env.start_timer = 0
     env.cars[0].gear = 1
     before = env.remaining_time
-    for _ in range(5):
+    env.cars[0].gear = 1
+    while env.lap == 0:
         env.cars[0].apply_controls(True, False, 0.0)
         env.step((False, False, 0.0))
-        if env.remaining_time > before:
-            break
     assert env.remaining_time > before
     env.close()

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -23,7 +23,7 @@ def test_wrap_position():
     car = Car(x=110.0, y=-5.0)
     track.wrap_position(car)
     assert 0.0 <= car.x < track.width
-    assert 0.0 <= car.y < track.height
+    assert car.y == -5.0
 
 
 def test_distance():


### PR DESCRIPTION
## Summary
- wrap only horizontal track position so cars can fall off road
- crash the player if a billboard is hit or the car leaves bounds
- remove quarter-lap time extensions
- show finish or time-up banner on screen
- adjust tests for new physics

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest tests/test_track.py tests/test_timer_checkpoint.py tests/test_billboard_collision.py -q`
- `python -m pytest -q` *(fails: test_puddle_slowdown_improved, test_lap_counter, test_draw_road_polygon_offset)*

------
https://chatgpt.com/codex/tasks/task_e_68565c44b0488324a9fc737bc0c274da