### PR TITLE
Limit time bonus to lap

### DIFF
--- a/super_pole_position/ui/arcade.py
+++ b/super_pole_position/ui/arcade.py
@@ -471,6 +471,12 @@ class Pseudo3DRenderer:
                 ty = height // 2 - text.get_height() // 2
                 self.screen.blit(text, (tx, ty))
 
+        if self.start_font and getattr(env, "time_extend_flash", 0) > 0:
+            text = self.start_font.render("EXTENDED TIME", True, (255, 255, 0))
+            tx = width // 2 - text.get_width() // 2
+            ty = height // 2 + 40
+            self.screen.blit(text, (tx, ty))
+
         # Scanline effect
 
         if self.scanline_alpha > 0:

--- a/tests/test_arcade_parity.py
+++ b/tests/test_arcade_parity.py
@@ -35,6 +35,7 @@ def measure_puddle_ratio() -> float:
     env = PolePositionEnv(render_mode="human")
     env.track = Track(width=200.0, height=200.0, puddles=[Puddle(x=50, y=50, radius=10)])
     env.reset()
+    env.cars[0].y = 50
     env.step({"throttle": True, "brake": False, "steer": 0.0})
     pre = env.cars[0].speed
     env.step({"throttle": False, "brake": False, "steer": 0.0})

--- a/tests/test_lap_counter.py
+++ b/tests/test_lap_counter.py
@@ -21,10 +21,10 @@ def test_lap_counter():
     env = PolePositionEnv(render_mode="human", mode="race")
     env.reset()
     env.start_timer = 0
-    for i in range(4):
-        env.cars[0].x = env.track.start_x - 1
+    for _ in range(5):
+        env.cars[0].x = env.track.start_x + env.track.width - 1
         env.step((False, False, 0.0))
-        env.cars[0].x = env.track.start_x + 1
+        env.cars[0].x = env.track.start_x + env.track.width + 1
         env.step((False, False, 0.0))
     assert env.lap >= 4
     env.close()

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,4 +1,5 @@
 import types
+import math
 import pytest
 pygame = pytest.importorskip("pygame")  # noqa: E402
 from super_pole_position.ui.arcade import Pseudo3DRenderer  # noqa: E402
@@ -9,8 +10,8 @@ def test_draw_road_polygon_offset():
     screen = pygame.display.set_mode((320, 240))
     renderer = Pseudo3DRenderer(screen)
     env = types.SimpleNamespace(
-        cars=[types.SimpleNamespace(angle=0.0, steering=0.5)],
-        track=types.SimpleNamespace(),
+        cars=[types.SimpleNamespace(angle=0.0, steering=0.5, x=0.0)],
+        track=types.SimpleNamespace(angle_at=lambda x: math.pi / 8),
     )
     poly = renderer.draw_road_polygon(env)
     width = screen.get_width()

--- a/tests/test_timer_checkpoint.py
+++ b/tests/test_timer_checkpoint.py
@@ -23,10 +23,9 @@ def test_checkpoint_timer_rollover():
     env.start_timer = 0
     env.cars[0].gear = 1
     before = env.remaining_time
-    for _ in range(5):
-        env.cars[0].apply_controls(True, False, 0.0)
-        env.step((False, False, 0.0))
-        if env.remaining_time > before:
-            break
+    env.cars[0].x = env.track.start_x - 1
+    env.step((False, False, 0.0))
+    env.cars[0].x = env.track.start_x + 1
+    env.step((False, False, 0.0))
     assert env.remaining_time > before
     env.close()


### PR DESCRIPTION
## Summary
- simplify timer logic by removing quarter-lap checkpoints
- display an "EXTENDED TIME" message after lap completion
- adjust unit tests for lap-based time bonus only

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68565c44b0488324a9fc737bc0c274da