### PR TITLE
Add scoreboard sync service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Parameterized scanline effect intensity via `config.arcade_parity.yaml`.
 - Reduced default scanline darkness for a softer CRT vibe.
 - Lap times now sent to the scoreboard API at each lap and race end.
+- Added `scoreboard-sync` command to mirror scores from a remote server.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,14 @@ python -m super_pole_position.server.api
 
 Use `GET /scores` to list results and `POST /scores` to submit new scores.
 
+### Scoreboard Sync Service
+
+Keep your local scoreboard fresh with:
+
+```bash
+spp scoreboard-sync --host 127.0.0.1 --port 8000 --interval 30
+```
+
 ---
 
 ## 🎶 **CREDITS & INSPIRATION**

--- a/super_pole_position/cli.py
+++ b/super_pole_position/cli.py
@@ -50,6 +50,10 @@ def main() -> None:
 
     sub.add_parser("hiscore")
     sub.add_parser("reset-scores")
+    s = sub.add_parser("scoreboard-sync")
+    s.add_argument("--host", default="127.0.0.1")
+    s.add_argument("--port", type=int, default=8000)
+    s.add_argument("--interval", type=float, default=60.0)
     args = parser.parse_args()
 
     if args.cmd == "hiscore":
@@ -62,6 +66,11 @@ def main() -> None:
         answer = input("Reset all scores? [y/N]: ")
         if answer.lower().startswith("y"):
             reset_scores(Path(__file__).parent / "evaluation" / "scores.json")
+        return
+    if args.cmd == "scoreboard-sync":
+        from .server import sync
+
+        sync.start_service(args.host, args.port, args.interval)
         return
 
     if args.cmd == "qualify":

--- a/super_pole_position/server/sync.py
+++ b/super_pole_position/server/sync.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Background scoreboard sync service."""
+
+import json
+import os
+import time
+from pathlib import Path
+from urllib import request
+
+from ..evaluation import scores
+
+
+DEFAULT_INTERVAL = 60.0
+
+
+def sync_once(file: Path, host: str = "127.0.0.1", port: int = 8000) -> bool:
+    """Fetch remote scores and merge with local scoreboard."""
+    url = f"http://{host}:{port}/scores"
+    try:
+        with request.urlopen(url, timeout=1) as resp:  # pragma: no cover - network
+            data = json.loads(resp.read())
+            remote = data.get("scores", [])
+    except Exception as exc:  # pragma: no cover - network failure
+        print(f"sync fetch error: {exc}", flush=True)
+        return False
+
+    local = scores.load_scores(file)
+    merged = sorted(local + remote, key=lambda s: -s["score"])[:10]
+    try:
+        file.write_text(json.dumps({"scores": merged}, indent=2))
+    except Exception as exc:  # pragma: no cover - file error
+        print(f"sync write error: {exc}", flush=True)
+        return False
+    return True
+
+
+def start_service(
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    interval: float = DEFAULT_INTERVAL,
+) -> None:
+    """Run sync loop. Stops after one iteration in FAST_TEST mode."""
+    file = Path(os.getenv("SPP_SCORES", scores._DEFAULT_FILE))
+    once = os.getenv("FAST_TEST", "") == "1"
+    while True:
+        sync_once(file, host, port)
+        if once:
+            break
+        time.sleep(interval)

--- a/tests/test_scoreboard_sync.py
+++ b/tests/test_scoreboard_sync.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Test scoreboard sync service."""
+
+from pathlib import Path
+
+from super_pole_position.server import sync
+
+
+def test_sync_once(monkeypatch, tmp_path: Path) -> None:
+    file = tmp_path / "scores.json"
+
+    class Dummy:
+        status = 200
+
+        def read(self) -> bytes:
+            return b'{"scores": [{"name": "remote", "score": 5}]}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    def fake_urlopen(url: str, timeout: int = 1):
+        return Dummy()
+
+    monkeypatch.setattr(sync.request, "urlopen", fake_urlopen)
+
+    assert sync.sync_once(file, host="dummy", port=0)
+    assert "remote" in file.read_text()


### PR DESCRIPTION
## Summary
- add a background scoreboard sync service
- expose `scoreboard-sync` subcommand
- document usage in the README
- note addition in CHANGELOG
- cover service with a new test

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566e1edc7c8324b39094b207f21413