### PR TITLE
Add global audio volume configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Parameterized scanline effect intensity via `config.arcade_parity.yaml`.
 - Reduced default scanline darkness for a softer CRT vibe.
 - Lap times now sent to the scoreboard API at each lap and race end.
+- Added `audio_volume` setting in `config.py` controlling pygame mixer volume.

--- a/config.arcade_parity.yaml
+++ b/config.arcade_parity.yaml
@@ -8,4 +8,5 @@ engine_pitch_factor: 3100.0
 scanline_step: 2
 scanline_spacing: 2
 scanline_alpha: 60
+audio_volume: 0.8
 

--- a/super_pole_position/config.py
+++ b/super_pole_position/config.py
@@ -11,7 +11,8 @@ except Exception:  # pragma: no cover - PyYAML optional
     yaml = None
 
 DEFAULTS = {
-    "puddle": {"speed_factor": 0.65, "angle_jitter": 0.2}
+    "puddle": {"speed_factor": 0.65, "angle_jitter": 0.2},
+    "audio_volume": 0.8,
 }
 
 CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.arcade_parity.yaml"
@@ -31,6 +32,11 @@ def load_parity_config() -> dict[str, Any]:
     cfg = DEFAULTS | data
     if "puddle" in data:
         cfg["puddle"] = DEFAULTS["puddle"] | data.get("puddle", {})
+    if "audio_volume" in data:
+        try:
+            cfg["audio_volume"] = float(data["audio_volume"])
+        except (TypeError, ValueError):
+            cfg["audio_volume"] = DEFAULTS["audio_volume"]
     return cfg
 
 def load_arcade_parity() -> dict[str, float]:

--- a/super_pole_position/ui/arcade.py
+++ b/super_pole_position/ui/arcade.py
@@ -19,6 +19,12 @@ from pathlib import Path
 from typing import Dict
 
 
+from ..config import load_parity_config
+
+
+_AUDIO_CFG = load_parity_config()
+AUDIO_VOLUME = float(_AUDIO_CFG.get("audio_volume", 0.8))
+
 def _load_config() -> dict:
     """Return arcade parity config from ``config.arcade_parity.yaml``.
 
@@ -128,7 +134,10 @@ class ArcadeRenderer:
         if pygame and os.environ.get("AUDIO", "1") != "0":
             pygame.mixer.init()
             self.channels = [pygame.mixer.Channel(i) for i in range(3)]
+            for ch in self.channels:
+                ch.set_volume(AUDIO_VOLUME)
             silent = pygame.mixer.Sound(buffer=b"\0\0")
+            silent.set_volume(AUDIO_VOLUME)
             self.engine_sound = silent
             self.skid_sound = silent
             crash_path = (
@@ -141,6 +150,7 @@ class ArcadeRenderer:
                 # ``crash.wav`` is not included in this repository. A silent
                 # placeholder sound avoids load errors during tests.
                 self.crash_sound = pygame.mixer.Sound(str(crash_path))
+                self.crash_sound.set_volume(AUDIO_VOLUME)
             except Exception:  # pragma: no cover - missing audio
                 self.crash_sound = silent
         else:


### PR DESCRIPTION
## Summary
- expose `audio_volume` in config module and YAML
- apply mixer volume when initializing pygame audio
- document config option in CHANGELOG

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68566e1edc7c8324b39094b207f21413