### PR TITLE
Add CPUCar AI and road helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,5 @@
 - Added `audio_volume` setting in `config.py` controlling pygame mixer volume.
 - Added `scoreboard-sync` command to mirror scores from a remote server.
 - Introduced `TrackCurve` helper and new `fuji_curve` track data.
+- Added `CPUCar` AI with blocking behaviour and `Track.is_on_road` helper.
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Press **Enter** to begin or **Esc** to quit.
 🛞 **Two-speed gearbox with torque kick**
 🪧 **Billboards shatter with time penalty**
 🌱 **Dynamic friction zones**
+🚗 **CPUCar opponents with blocking behaviour**
 🌄 **Horizon sway & sprite scaling**
 📻 **Engine pitch scales with RPM**
 

--- a/super_pole_position/ai_cpu.py
+++ b/super_pole_position/ai_cpu.py
@@ -1,0 +1,52 @@
+"""Simple CPU opponent logic."""
+
+from dataclasses import dataclass, field
+
+from .physics.car import Car
+from .physics.track import Track
+
+
+@dataclass
+class CPUCar(Car):
+    """Rudimentary AI-controlled car."""
+
+    x: float = 0.0
+    y: float = 0.0
+    angle: float = 0.0
+    speed: float = 0.0
+    preferred_lane: float = 0.0
+    state: str = "CRUISE"
+    _block_time: float = field(default=0.0, init=False)
+
+    def __post_init__(self) -> None:
+        super().__init__(self.x, self.y, self.angle, self.speed)
+
+    def blocking(self, player: Car) -> bool:
+        """Return ``True`` if player is close enough to trigger blocking."""
+
+        behind = self.x - player.x
+        if behind < 0:
+            behind +=  self.max_speed * 2  # track wrap approx
+        same_lane = abs(self.y - player.y) < 0.5
+        return behind <= 7.0 and same_lane
+
+    def update(self, dt: float, track: Track, player: Car) -> None:
+        """Advance AI state machine."""
+
+        if self.state == "CRUISE" and self.blocking(player):
+            self.state = "BLOCK"
+            self._block_time = 1.0
+
+        if self.state == "BLOCK":
+            direction = -1.0 if player.y > self.y else 1.0
+            self.y += direction * dt
+            self._block_time -= dt
+            if self._block_time <= 0:
+                self.state = "RECOVER"
+
+        if self.state == "RECOVER":
+            diff = self.preferred_lane - self.y
+            if abs(diff) < 0.1:
+                self.state = "CRUISE"
+            else:
+                self.y += diff * dt

--- a/super_pole_position/physics.py
+++ b/super_pole_position/physics.py
@@ -1,0 +1,21 @@
+"""Physics helpers used by the arcade-faithful build."""
+
+from typing import Tuple
+
+from .physics.track import Track
+
+
+def curvilinear_coords(track: Track, x: float, y: float) -> Tuple[float, float]:
+    """Return ``(s, d)`` coordinates for position on ``track``."""
+
+    if track.curve is None:
+        s = (x - track.start_x) % track.width
+        center_y = track.y_at(x)
+        d = y - center_y
+        return s, d
+
+    prog = track.progress((x, y)) * track.curve.total_length
+    cx, cy = track.curve.point_at(prog)
+    nx, ny = track.curve.normal_at(prog)
+    d = (x - cx) * nx + (y - cy) * ny
+    return prog, d

--- a/super_pole_position/physics/track.py
+++ b/super_pole_position/physics/track.py
@@ -120,18 +120,25 @@ class Track:
         dx = p1[0] - p0[0]
         return math.atan2(dy, dx)
 
-    def on_road(self, car) -> bool:
-        """Return ``True`` if ``car`` is within the paved road bounds."""
+    def is_on_road(self, x: float, y: float) -> bool:
+        """Return ``True`` if coordinates are within the paved bounds."""
+
         if self.curve:
-            prog = self.progress(car) * self.curve.total_length
+            prog = self.progress((x, y)) * self.curve.total_length
             cx, cy = self.curve.point_at(prog)
             tx, ty = self.curve.normal_at(prog)
-            dx = car.x - cx
-            dy = car.y - cy
+            dx = x - cx
+            dy = y - cy
             offset = abs(dx * tx + dy * ty)
             return offset <= self.road_width / 2
-        center_y = self.y_at(car.x)
-        return abs(car.y - center_y) <= self.road_width / 2
+
+        center_y = self.y_at(x)
+        return abs(y - center_y) <= self.road_width / 2
+
+    def on_road(self, car) -> bool:
+        """Return ``True`` if ``car`` is within the paved road bounds."""
+
+        return self.is_on_road(car.x, car.y)
 
     @classmethod
     def load(cls, name: str) -> "Track":

--- a/tests/test_cpucar.py
+++ b/tests/test_cpucar.py
@@ -1,0 +1,10 @@
+from super_pole_position.ai_cpu import CPUCar
+from super_pole_position.physics.car import Car
+
+
+def test_cpucar_blocking():
+    cpu = CPUCar(x=0.0, y=1.0)
+    player = Car(x=-6.0, y=1.2, speed=5.0)
+    assert cpu.blocking(player)
+    player.y = 2.0
+    assert not cpu.blocking(player)

--- a/tests/test_is_on_road.py
+++ b/tests/test_is_on_road.py
@@ -1,0 +1,7 @@
+from super_pole_position.physics.track import Track
+
+
+def test_is_on_road_basic():
+    track = Track(width=10.0, height=2.0, road_width=2.0)
+    assert track.is_on_road(5.0, 1.0)
+    assert not track.is_on_road(5.0, 2.1)

--- a/tests/test_lap_timer_edge.py
+++ b/tests/test_lap_timer_edge.py
@@ -1,0 +1,15 @@
+from super_pole_position.envs.pole_position import PolePositionEnv
+
+
+def test_lap_timer_resets():
+    env = PolePositionEnv(render_mode="human", mode="race")
+    env.reset()
+    env.start_timer = 0
+    env.cars[0].gear = 1
+    env.cars[0].x = env.track.start_x + env.track.width - 1
+    env.step((False, False, 0.0))
+    env.cars[0].x = env.track.start_x + env.track.width + 1
+    env.step((False, False, 0.0))
+    assert env.last_lap_time is not None
+    assert env.lap_timer == 0.0
+    env.close()


### PR DESCRIPTION
## Summary
- add `CPUCar` class for simple opponent blocking logic
- expose curvilinear coordinate helper in new module
- introduce `Track.is_on_road` and tests
- verify lap timer reset edge case
- document features in README and CHANGELOG

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68567c0796dc8324824416a37f58c289