### PR TITLE
Add mute-bgm CLI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,5 @@
 - Added `audio_volume` setting in `config.py` controlling pygame mixer volume.
 - Added `scoreboard-sync` command to mirror scores from a remote server.
 - Introduced `TrackCurve` helper and new `fuji_curve` track data.
+- Added `--mute-bgm` CLI flag to disable background music.
 

--- a/README.md
+++ b/README.md
@@ -184,3 +184,4 @@ spp scoreboard-sync --host 127.0.0.1 --port 8000 --interval 30
 - All original arcade mechanics recreated: slipstreaming, off-road slowdown, and timed checkpoints
 - Try `--hyper` for a *next-gen AI challenge*
 - Display performance metrics by setting `PERF_HUD=1`
+- Mute background music via `--mute-bgm`

--- a/super_pole_position/cli.py
+++ b/super_pole_position/cli.py
@@ -42,11 +42,13 @@ def main() -> None:
     q.add_argument("--agent", choices=list(AGENT_MAP.keys()), default="null")
     q.add_argument("--track", default="fuji")
     q.add_argument("--render", action="store_true")
+    q.add_argument("--mute-bgm", action="store_true", help="Disable background music")
 
     r = sub.add_parser("race")
     r.add_argument("--agent", choices=list(AGENT_MAP.keys()), default="null")
     r.add_argument("--track", default="fuji")
     r.add_argument("--render", action="store_true")
+    r.add_argument("--mute-bgm", action="store_true", help="Disable background music")
 
     sub.add_parser("hiscore")
     sub.add_parser("reset-scores")
@@ -55,6 +57,10 @@ def main() -> None:
     s.add_argument("--port", type=int, default=8000)
     s.add_argument("--interval", type=float, default=60.0)
     args = parser.parse_args()
+    if getattr(args, "mute_bgm", False):
+        os.environ["MUTE_BGM"] = "1"
+    else:
+        os.environ.setdefault("MUTE_BGM", "0")
 
     if args.cmd == "hiscore":
         file = Path(__file__).parent / "evaluation" / "scores.json"

--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -816,6 +816,8 @@ class PolePositionEnv(gym.Env):
     def _play_bgm_loop(self) -> None:
         """Start background music playback once."""
 
+        if os.environ.get("MUTE_BGM", "0") == "1":
+            return
         if sa is None and pg_mixer is None:
             return
         if self.bgm_wave is None:

--- a/tests/test_cli_mute_bgm.py
+++ b/tests/test_cli_mute_bgm.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import pytest  # noqa: F401
+from super_pole_position import cli
+
+
+def fake_run_episode(env, agents):
+    return 0.0
+
+
+def test_cli_mute_bgm(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pygame", None)
+    monkeypatch.setattr(cli, "run_episode", fake_run_episode)
+    monkeypatch.setattr(sys, "argv", ["spp", "qualify", "--mute-bgm"])
+    monkeypatch.dict(os.environ, {"FAST_TEST": "1"}, clear=False)
+    cli.main()
+    assert os.environ.get("MUTE_BGM") == "1"


### PR DESCRIPTION
## Summary
- add `--mute-bgm` option to CLI
- check `MUTE_BGM` in envs to silence background music
- document the new flag in README and CHANGELOG
- test that CLI sets the environment variable

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68567c0796dc8324824416a37f58c289