### PR TITLE
Fix test suite for CI

### DIFF
--- a/tests/test_cli_mute_bgm.py
+++ b/tests/test_cli_mute_bgm.py
@@ -13,7 +13,5 @@ def test_cli_mute_bgm(monkeypatch):
     monkeypatch.setattr(cli, "run_episode", fake_run_episode)
     monkeypatch.setattr(sys, "argv", ["spp", "qualify", "--mute-bgm"])
     monkeypatch.setenv("FAST_TEST", "1")
-    monkeypatch.dict(os.environ, {"FAST_TEST": "1"}, clear=False)
-
     cli.main()
     assert os.environ.get("MUTE_BGM") == "1"


### PR DESCRIPTION
## Summary
- fix `test_cli_mute_bgm` to avoid deprecated monkeypatch API

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685680df1dd08324823955c8f057edbf