### PR TITLE
Fix gear-aware engine pitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,5 @@
 - Introduced `TrackCurve` helper and new `fuji_curve` track data.
 - Added `--mute-bgm` CLI flag to disable background music.
 - Added `CPUCar` AI with blocking behaviour and `Track.is_on_road` helper.
+- Engine pitch now factors in current gear for smoother shifts.
 

--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -44,10 +44,11 @@ ENGINE_BASE_FREQ = _PARITY_CONFIG.get("engine_base_freq", 400.0)
 ENGINE_PITCH_FACTOR = _PARITY_CONFIG.get("engine_pitch_factor", 3000.0)
 
 
-def engine_pitch(rpm: float) -> float:
-    """Return engine frequency in Hz for ``rpm`` (0..1)."""
+def engine_pitch(rpm: float, gear: int = 0) -> float:
+    """Return engine frequency in Hz for ``rpm`` and ``gear``."""
 
-    return ENGINE_BASE_FREQ + ENGINE_PITCH_FACTOR * rpm
+    gear_factor = 1.0 + 0.1 * max(0, gear)
+    return ENGINE_BASE_FREQ + ENGINE_PITCH_FACTOR * rpm * gear_factor
 
 FAST_TEST = bool(int(os.getenv("FAST_TEST", "0")))
 PARITY_CFG = load_parity_config()
@@ -748,7 +749,7 @@ class PolePositionEnv(gym.Env):
             return base + harm2 + harm3 + rumble
 
         def panned_engine(car):
-            freq = engine_pitch(car.rpm())
+            freq = engine_pitch(car.rpm(), car.gear)
             pan = (car.y - self.track.height / 2) / (self.track.height / 2)
             pan = max(-1.0, min(1.0, pan))
             wave = engine_wave(freq)

--- a/tests/test_arcade_parity.py
+++ b/tests/test_arcade_parity.py
@@ -52,7 +52,7 @@ def test_puddle_slowdown_improved():
 def test_engine_pitch_improved():
     baseline_path = Path('benchmarks/baseline_engine_pitch.txt')
     baseline_val = float(baseline_path.read_text().split('=')[1])
-    new_val = engine_pitch(0.5)
+    new_val = engine_pitch(0.5, 0)
     assert new_val - baseline_val >= 49.9
 
 def _read_baseline() -> int:


### PR DESCRIPTION
## Summary
- adjust engine_pitch to factor in gear
- use gear when generating engine audio
- update arcade parity test
- note change in CHANGELOG

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685685536880832494200fd929021e6a