### PR TITLE
Enable touchscreen virtual joystick

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,15 @@ Press **Enter** to begin or **Esc** to quit.
 
 For more details see [GAMEPLAY_FAQ.md](GAMEPLAY_FAQ.md).
 
-🕹️ **CAR 2:** _(AI-Driven)_  
-🤖 **Automated racing, planning, and learning**  
+### 🖐️ Virtual Joystick
+Install the `pygame-virtual-joystick` library to control the car on touchscreens.
+Enable it with `--virtual-joystick` when launching a race or qualifying run:
+```bash
+spp race --render --virtual-joystick
+```
+
+🕹️ **CAR 2:** _(AI-Driven)_
+🤖 **Automated racing, planning, and learning**
 
 📡 **Live Monitoring Mode** – Track AI behavior in real-time, with zero-latency logging.
 
@@ -186,3 +193,4 @@ spp scoreboard-sync --host 127.0.0.1 --port 8000 --interval 30
 - Try `--hyper` for a *next-gen AI challenge*
 - Display performance metrics by setting `PERF_HUD=1`
 - Mute background music via `--mute-bgm`
+- Use `--virtual-joystick` for touchscreen controls

--- a/super_pole_position/agents/keyboard_agent.py
+++ b/super_pole_position/agents/keyboard_agent.py
@@ -23,12 +23,29 @@ class KeyboardAgent(BaseLLMAgent):
     def __init__(self) -> None:
         self._last_up = False
         self._last_down = False
+        self.use_virtual = False
+        if os.getenv("VIRTUAL_JOYSTICK", "0") == "1" and pygame is not None:
+            try:  # pragma: no cover - optional dependency
+                import pygame_virtual_joystick as pvj  # type: ignore
+
+                pvj.init()
+                self.use_virtual = True
+            except Exception:
+                self.use_virtual = False
 
     def act(self, observation) -> dict:
         """Return a steering command based on pressed keys."""
         if pygame is None:
             # Without pygame we return a neutral action. 🤖
             return {"throttle": 0, "brake": 0, "steer": 0.0, "gear": 0}
+
+        if self.use_virtual:
+            try:  # pragma: no cover - optional dependency
+                import pygame_virtual_joystick as pvj  # type: ignore
+
+                pvj.update()
+            except Exception:
+                pass
 
         # 🎮 Capture current key states
         keys = pygame.key.get_pressed()

--- a/super_pole_position/cli.py
+++ b/super_pole_position/cli.py
@@ -43,12 +43,22 @@ def main() -> None:
     q.add_argument("--track", default="fuji")
     q.add_argument("--render", action="store_true")
     q.add_argument("--mute-bgm", action="store_true", help="Disable background music")
+    q.add_argument(
+        "--virtual-joystick",
+        action="store_true",
+        help="Enable on-screen controls for touch devices",
+    )
 
     r = sub.add_parser("race")
     r.add_argument("--agent", choices=list(AGENT_MAP.keys()), default="null")
     r.add_argument("--track", default="fuji")
     r.add_argument("--render", action="store_true")
     r.add_argument("--mute-bgm", action="store_true", help="Disable background music")
+    r.add_argument(
+        "--virtual-joystick",
+        action="store_true",
+        help="Enable on-screen controls for touch devices",
+    )
 
     sub.add_parser("hiscore")
     sub.add_parser("reset-scores")
@@ -61,6 +71,10 @@ def main() -> None:
         os.environ["MUTE_BGM"] = "1"
     else:
         os.environ.setdefault("MUTE_BGM", "0")
+    if getattr(args, "virtual_joystick", False):
+        os.environ["VIRTUAL_JOYSTICK"] = "1"
+    else:
+        os.environ.setdefault("VIRTUAL_JOYSTICK", "0")
 
     if args.cmd == "hiscore":
         file = Path(__file__).parent / "evaluation" / "scores.json"


### PR DESCRIPTION
## Summary
- add `--virtual-joystick` flag to CLI
- initialize pygame-virtual-joystick when requested
- document touchscreen controls in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685685536880832494200fd929021e6a