### PR TITLE
Document zero-byte asset placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,6 @@
 - Added `--mute-bgm` CLI flag to disable background music.
 - Added `CPUCar` AI with blocking behaviour and `Track.is_on_road` helper.
 - Added placeholder sprite and audio asset directories.
+- Placeholder sprite and audio files are now committed as zero-byte stubs.
 - Engine pitch now factors in current gear for smoother shifts.
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Press **Enter** to begin or **Esc** to quit.
 🌀 **Toroidal Racing Physics:** No edges, no limits—just infinite speed.
 🖼️ **Retro ASCII sprites** for cars, billboards and explosions.
 🎨 **Placeholder PNGs** stored in `assets/sprites` for arcade-faithful builds.
+These are zero-byte stubs included only so the file paths exist.
 🚀 **Hyper Mode** for uncapped speed and obstacle chaos.
 🕹️ **Arcade-accurate mechanics**: slipstream boost, off-road slowdown, crash penalties
 🛞 **Two-speed gearbox with torque kick**
@@ -130,6 +131,7 @@ This avoids importing heavy GPU libraries until you explicitly load the GPT plan
 
 ### Assets
 Placeholder PNG and WAV files live under `assets/sprites` and `assets/audio`.
+These files are empty stubs so the project contains no binary data.
 See `assets/sprites/SPRITES.md` and `assets/audio/AUDIO.md` for the full list.
 Replace them with real graphics and samples for a fully authentic experience.
 

--- a/assets/audio/AUDIO.md
+++ b/assets/audio/AUDIO.md
@@ -10,4 +10,4 @@ Placeholder WAV files for sound effects and music.
 - `goal.wav` – finish line voice
 - `bgm.wav` – attract mode background music
 
-These files contain 100 ms of silence and are meant to be replaced with real samples.
+These files are zero-byte placeholders. Replace them with real samples for sound to work.

--- a/assets/sprites/SPRITES.md
+++ b/assets/sprites/SPRITES.md
@@ -9,4 +9,4 @@ This file lists placeholder sprite images used in the arcade-faithful build.
 - `mt_fuji.png` – Mount Fuji background layer
 - `clouds.png` – parallax cloud layer
 
-All images are distributed as empty placeholders.
+All PNG files are zero-byte placeholders provided only to reserve the filenames.


### PR DESCRIPTION
## Summary
- clarify that placeholder PNG and WAV files are empty stubs
- note zero-byte placeholders in asset documentation
- mention stub assets in changelog

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685717e0367c8324ab518ba4f85ab278