### PR TITLE
Polish docs with examples and final emojis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,5 @@
 - Placeholder sprite and audio files are now committed as zero-byte stubs.
 - Engine pitch now factors in current gear for smoother shifts.
 
+📌 Keep racing for the next update! 🏁
+

--- a/GAMEPLAY_FAQ.md
+++ b/GAMEPLAY_FAQ.md
@@ -12,5 +12,6 @@
 - Stay on the road to maintain speed – off-road driving slows you down!
 - Use gentle steering to avoid skids.
 - Finish four laps as fast as possible to top the leaderboard.
+- For touchscreens try `--virtual-joystick`.
 
 Enjoy the ride! 🏁

--- a/PROGRESS_ARCADE_PARITY.md
+++ b/PROGRESS_ARCADE_PARITY.md
@@ -19,3 +19,5 @@
 - [x] Test suite for each new feature
 - [x] Stereo engine audio panned by car position
 - [x] Lap times posted to scoreboard API
+
+🎉 All core arcade mechanics implemented! 🏁

--- a/README.md
+++ b/README.md
@@ -217,3 +217,5 @@ python examples/animated_sprite.py
 - Esc – Quit the demo
 - Use `--virtual-joystick` for touchscreen controls
 
+🚗 Happy racing! 🏁
+

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,10 +6,15 @@ This document highlights planned milestones for upcoming releases.
 - Initial release with racing environment and CLI tools.
 - Basic leaderboard and score tracking.
 - Optional scoreboard HTTP API.
+- Self-hosted scoreboard service with JSON storage.
 
 ## 🏎️ v1.1.0
 - Enhanced telemetry output via WebSockets.
 - Visualization notebooks for replay analysis.
+- Integrated AI replay viewer.
 
 ## 🏆 v2.0.0
 - Community model submissions and tournament mode.
+- Split-screen multiplayer for human vs AI.
+
+🚧 More milestones to come! 🏁

--- a/SCOREBOARD_ENDPOINTS.md
+++ b/SCOREBOARD_ENDPOINTS.md
@@ -19,3 +19,14 @@ The server will listen on `127.0.0.1:8000` by default.
 
 Scores are stored in `scores.json` inside the package directory unless the
 `SPP_SCORES` environment variable points to a different file.
+
+## 📝 Example usage
+
+```bash
+curl http://127.0.0.1:8000/scores
+curl -X POST http://127.0.0.1:8000/scores \
+  -H "Content-Type: application/json" \
+  -d '{"name":"TurboGPT","score":1200}'
+```
+
+🏁

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -10,3 +10,11 @@ For each completed episode two files are written:
 
 These files are produced automatically by `super_pole_position.evaluation.logger`
 and are useful for tracking historical performance.
+
+Run a quick race to generate logs:
+
+```bash
+spp race --agent null --track fuji
+```
+
+Logs will appear under `benchmarks/YYYY-MM-DD/` 📊


### PR DESCRIPTION
## Summary
- add scoreboard API usage example
- expand roadmap milestones
- mark arcade parity progress as complete
- add touch control tip in gameplay FAQ
- include benchmark run example
- sign off docs with racing emoji

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_685722054c608324a9789fe4c0b092c0