### PR TITLE
Add sprite loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added `CPUCar` AI with blocking behaviour and `Track.is_on_road` helper.
 - Added placeholder sprite and audio asset directories.
 - Placeholder sprite and audio files are now committed as zero-byte stubs.
+- Added `load_sprite` helper to load PNGs when available with ASCII fallback.
 - Engine pitch now factors in current gear for smoother shifts.
 
 📌 Keep racing for the next update! 🏁

--- a/assets/sprites/SPRITES.md
+++ b/assets/sprites/SPRITES.md
@@ -1,12 +1,19 @@
 # Sprite Assets
 
-This file lists placeholder sprite images used in the arcade-faithful build.
+This file lists sprite names that the engine expects. Each PNG is a zero-byte
+stub so no binary data ships with the repository. Use these filenames when
+generating sprites programmatically.
 
-- `player_car.png` – player rear view, 32×32
-- `cpu_car.png` – CPU cars, front and rear views
-- `billboard_*.png` – eight billboard variants
-- `explosion_16f.png` – 16-frame explosion sheet, 64×64
-- `mt_fuji.png` – Mount Fuji background layer
-- `clouds.png` – parallax cloud layer
+- `player_car.png` – rear-view Formula 1 car. Size 32×32. Color hints: red body,
+  white cockpit.
+- `cpu_car.png` – other racers. Also 32×32. Provide both front and rear
+  perspectives for overtaking scenes.
+- `billboard_*.png` – eight road-side sign boards, each 32×32. These can share a
+  palette but display different logos.
+- `explosion_16f.png` – sprite sheet with 16 frames, each frame 32×32. Use this
+  for the crash animation.
+- `mt_fuji.png` – wide background of Mount Fuji. Target width ~256, height 64.
+- `clouds.png` – parallax layer for the sky, width 256, height ~32.
 
-All PNG files are zero-byte placeholders provided only to reserve the filenames.
+All files are empty placeholders. Replace them with generated pixel art at build
+time.

--- a/super_pole_position/ui/arcade.py
+++ b/super_pole_position/ui/arcade.py
@@ -65,7 +65,13 @@ _PARITY_CFG = _load_config()
 SCANLINE_SPACING = int(_PARITY_CFG.get("scanline_spacing", 2))
 SCANLINE_ALPHA = int(_PARITY_CFG.get("scanline_alpha", 40))
 
-from .sprites import BILLBOARD_ART, CAR_ART, EXPLOSION_FRAMES, ascii_surface
+from .sprites import (
+    BILLBOARD_ART,
+    CAR_ART,
+    EXPLOSION_FRAMES,
+    ascii_surface,
+    load_sprite,
+)
 from ..evaluation.scores import load_scores
 
 try:
@@ -251,9 +257,15 @@ class Pseudo3DRenderer:
         self.sky_color = (100, 150, 255)
         self.ground_color = (40, 40, 40)
         self.car_color = (255, 0, 0)
-        self.car_sprite = ascii_surface(CAR_ART)
-        self.billboard_sprite = ascii_surface(BILLBOARD_ART)
-        self.explosion_frames = [ascii_surface(f) for f in EXPLOSION_FRAMES]
+        self.car_sprite = load_sprite("player_car", CAR_ART)
+        self.billboard_sprite = load_sprite("billboard_1", BILLBOARD_ART)
+        sheet = load_sprite("explosion_16f")
+        if sheet:
+            w = sheet.get_width() // 16
+            h = sheet.get_height()
+            self.explosion_frames = [sheet.subsurface((i * w, 0, w, h)) for i in range(16)]
+        else:
+            self.explosion_frames = [ascii_surface(f) for f in EXPLOSION_FRAMES]
         self.scanline_spacing = SCANLINE_SPACING
         self.scanline_alpha = SCANLINE_ALPHA
 

--- a/super_pole_position/ui/sprites.py
+++ b/super_pole_position/ui/sprites.py
@@ -9,6 +9,7 @@ Description: Module for Super Pole Position.
 """
 
 import os
+from pathlib import Path
 
 # Hide pygame's greeting for cleaner logs
 os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
@@ -60,6 +61,8 @@ def ascii_surface(ascii_art: list[str], scale: int = 1) -> "pygame.Surface | Non
     """Return a pygame surface from ASCII art or ``None`` if pygame missing."""
     if not pygame:
         return None
+    if not ascii_art:
+        return pygame.Surface((1, 1), pygame.SRCALPHA)
     height = len(ascii_art)
     width = max(len(line) for line in ascii_art)
     surf = pygame.Surface((width, height), pygame.SRCALPHA)
@@ -71,3 +74,29 @@ def ascii_surface(ascii_art: list[str], scale: int = 1) -> "pygame.Surface | Non
     if scale > 1:
         surf = pygame.transform.scale(surf, (width * scale, height * scale))
     return surf
+
+
+def load_sprite(name: str, ascii_art: list[str] | None = None) -> "pygame.Surface | None":
+    """Return a sprite loaded from ``assets/sprites`` or fallback to ASCII.
+
+    Parameters
+    ----------
+    name:
+        File name without extension.
+    ascii_art:
+        Optional ASCII art fallback.
+    """
+
+    if not pygame:
+        return ascii_surface(ascii_art or [])
+    base = os.getenv("SPRITE_DIR")
+    if base:
+        path = Path(base) / f"{name}.png"
+    else:
+        path = Path(__file__).resolve().parents[1] / "assets" / "sprites" / f"{name}.png"
+    if path.exists() and path.stat().st_size > 0:
+        try:
+            return pygame.image.load(str(path))
+        except Exception:
+            return ascii_surface(ascii_art or [])
+    return ascii_surface(ascii_art or [])

--- a/tests/test_sprite_loader.py
+++ b/tests/test_sprite_loader.py
@@ -1,0 +1,18 @@
+import pygame
+import pytest
+
+from super_pole_position.ui.sprites import load_sprite
+
+pygame = pytest.importorskip("pygame")
+
+
+def test_load_sprite_png(tmp_path, monkeypatch):
+    pygame.display.init()
+    img = pygame.Surface((4, 4))
+    img.fill((255, 0, 0))
+    fname = tmp_path / "sample.png"
+    pygame.image.save(img, str(fname))
+    monkeypatch.setenv("SPRITE_DIR", str(tmp_path))
+    surf = load_sprite("sample")
+    assert surf.get_size() == (4, 4)
+    pygame.display.quit()


### PR DESCRIPTION
## Summary
- generate placeholder PNG sprites for car, billboard, explosion
- load PNG sprites in `Pseudo3DRenderer`
- allow fallback sprite loading via `load_sprite`
- ensure ASCII surfaces handle empty art
- test new sprite loader helper
- add design notes to `SPRITES.md`
- keep binary sprites zero-byte

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68572f32a07483248e6059f951bcce47