### PR TITLE
Enable analog throttle

### DIFF
--- a/super_pole_position/physics/car.py
+++ b/super_pole_position/physics/car.py
@@ -24,7 +24,7 @@ class Car:
         self.speed = speed
         self.acceleration = 2.0
         # Two gear ratios: index 0=LOW, 1=HIGH
-        self.gear_max = [8.0, 15.0]
+        self.gear_max = [8.0, 19.0]
         self.gear = 0
         self.max_speed = self.gear_max[-1]
         self.turn_rate = 2.0  # rad/sec
@@ -45,26 +45,26 @@ class Car:
 
     def apply_controls(
         self,
-        throttle: bool,
-        brake: bool,
+        throttle: float,
+        brake: float,
         steering: float,
         dt: float = 1.0,
         track=None,
     ):
         """
         Updates the car's speed and angle based on throttle/brake/steering inputs.
-        :param throttle: If True, accelerate.
-        :param brake: If True, decelerate.
+        :param throttle: 0..1 amount of acceleration.
+        :param brake: 0..1 braking intensity.
         :param steering: Negative => turn left, Positive => turn right.
         :param dt: Timestep in seconds.
         :param track: Optional track to check for off-road slowdown.
         """
         # Accelerate / Decelerate with gear torque
         gear_factor = 1.0 + 0.5 * self.gear
-        if throttle:
-            self.speed += self.acceleration * gear_factor * dt
-        if brake:
-            self.speed -= self.acceleration * dt
+        if throttle > 0.0:
+            self.speed += self.acceleration * gear_factor * throttle * dt
+        if brake > 0.0:
+            self.speed -= self.acceleration * brake * dt
 
         # Clamp speed by current gear unless unlimited is enabled
         max_speed = self.gear_max[self.gear]

--- a/tests/test_nullagent.py
+++ b/tests/test_nullagent.py
@@ -23,7 +23,7 @@ def test_null_agent_completes_lap():
     env.start_timer = 0
     agent = NullAgent()
     steps = 0
-    while env.lap < 1 and steps < 200:
+    while env.lap < 1 and steps < 400:
         obs = env._get_obs()
         action = agent.act(obs)
         env.step(action)


### PR DESCRIPTION
## Summary
- support analog throttle/brake values in environment action space
- increase car top speed for high gear
- render at 60 FPS
- tweak NullAgent test for new timing

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68576f0866a88324a7129daf976538cf