### PR TITLE
Implement high-score utility and overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Placeholder sprite and audio files are now committed as zero-byte stubs.
 - Added `load_sprite` helper to load PNGs when available with ASCII fallback.
 - Engine pitch now factors in current gear for smoother shifts.
+- Added on-screen high-score display and `examples/reset_high_scores.py` utility.
 
 📌 Keep racing for the next update! 🏁
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ python -m super_pole_position.server.api
 
 Use `GET /scores` to list results and `POST /scores` to submit new scores.
 
+To clear your local high-score table run:
+
+```bash
+python examples/reset_high_scores.py
+```
+
 ### Scoreboard Sync Service
 
 Keep your local scoreboard fresh with:

--- a/examples/reset_high_scores.py
+++ b/examples/reset_high_scores.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Utility to clear the local high-score table."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from super_pole_position.evaluation.scores import reset_scores
+
+
+def main() -> None:
+    """Reset the scoreboard file to an empty list."""
+    default = Path(__file__).resolve().parents[1] / "super_pole_position" / "evaluation" / "scores.json"
+    file = Path(os.getenv("SPP_SCORES", default))
+    reset_scores(file)
+    print(f"High score table reset at {file}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual utility
+    main()

--- a/super_pole_position/ui/menu.py
+++ b/super_pole_position/ui/menu.py
@@ -27,6 +27,30 @@ except Exception:  # pragma: no cover - optional dependency
 from ..evaluation.scores import load_scores
 
 
+def _show_high_scores(screen, font) -> None:
+    """Display the top five scores until a key is pressed."""
+
+    scores = load_scores(None)[:5]
+    clock = pygame.time.Clock()
+    running = True
+    while running:
+        for event in pygame.event.get():
+            if event.type in {pygame.KEYDOWN, pygame.QUIT}:
+                running = False
+        screen.fill((0, 0, 0))
+        title = font.render("HIGH SCORES", True, (255, 255, 0))
+        screen.blit(title, (50, 30))
+        y = 70
+        for i, s in enumerate(scores, 1):
+            line = font.render(f"{i}. {s['name']} {s['score']}", True, (255, 255, 255))
+            screen.blit(line, (50, y))
+            y += 30
+        press = font.render("PRESS ANY KEY", True, (255, 255, 0))
+        screen.blit(press, (50, y + 20))
+        pygame.display.flip()
+        clock.tick(30)
+
+
 class MenuState:
     """Headless-friendly menu state machine."""
 
@@ -135,10 +159,7 @@ def main_loop(screen, seed: int | None = None) -> dict | None:
                 if result is None or isinstance(result, dict):
                     return result
                 if name == "H":
-                    scores = load_scores(None)
-                    print("=== HI-SCORES ===")
-                    for i, s in enumerate(scores, 1):
-                        print(f"{i:2d}. {s['name']} {s['score']}")
+                    _show_high_scores(screen, font)
         if backdrop:
             w = backdrop.get_width()
             screen.blit(backdrop, (-x_offset % w, 0))


### PR DESCRIPTION
## Summary
- add screen for viewing top five high scores
- provide `examples/reset_high_scores.py` for wiping scores
- document new reset script in README
- mention feature in CHANGELOG

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError for numpy and pygame)*

------
https://chatgpt.com/codex/tasks/task_e_685779437d5c83249519b06293f22403