### PR TITLE
Placeholder sprite generation

### DIFF
--- a/assets/sprites/generate_placeholders.py
+++ b/assets/sprites/generate_placeholders.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Generate placeholder PNG sprites for development."""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Dict, Tuple
+
+# Hide pygame greeting and use dummy video driver for headless generation
+os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+try:
+    import pygame
+except Exception:  # pragma: no cover - optional dependency
+    pygame = None
+
+DEFAULT_COLOR = (128, 128, 128)
+COLOR_MAP: Dict[str, Tuple[int, int, int]] = {
+    "player_car.png": (200, 0, 0),
+    "cpu_car.png": (0, 0, 200),
+    "explosion_16f.png": (255, 150, 0),
+    "mt_fuji.png": (50, 50, 50),
+    "clouds.png": (180, 180, 180),
+}
+
+
+def _parse_sprite_specs(md_file: Path) -> Dict[str, Tuple[int, int]]:
+    """Return mapping of sprite filename to (width, height)."""
+
+    pattern = re.compile(r"`([^`]+)`.*?Size (\d+)×(\d+)")
+    specs: Dict[str, Tuple[int, int]] = {}
+    if not md_file.exists():
+        return specs
+    for line in md_file.read_text().splitlines():
+        match = pattern.search(line)
+        if match:
+            name = match.group(1)
+            specs[name] = (int(match.group(2)), int(match.group(3)))
+    return specs
+
+
+def _write_sprite(path: Path, size: Tuple[int, int], color: Tuple[int, int, int], text: str) -> None:
+    if pygame is None:
+        return
+    surf = pygame.Surface(size)
+    surf.fill(color)
+    font = pygame.font.Font(None, 12)
+    label = font.render(text, True, (255, 255, 255))
+    rect = label.get_rect(center=(size[0] // 2, size[1] // 2))
+    surf.blit(label, rect)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pygame.image.save(surf, str(path))
+
+
+def generate_sprite(name: str, path: Path, size_map: Dict[str, Tuple[int, int]]) -> None:
+    """Create a placeholder image for ``name`` if missing."""
+
+    if pygame is None:
+        return
+    if path.exists() and path.stat().st_size > 0:
+        return
+
+    size = size_map.get(name + ".png", (32, 32))
+    color = DEFAULT_COLOR
+    for key, value in COLOR_MAP.items():
+        if name + ".png" == key or key.startswith("billboard") and name.startswith("billboard"):
+            color = value
+            break
+
+    _write_sprite(path, size, color, name)
+
+
+def generate_all(base: Path | None = None) -> None:
+    """Generate placeholders for all sprites listed in SPRITES.md."""
+
+    if pygame is None:
+        return
+    base = base or Path(__file__).resolve().parent
+    specs = _parse_sprite_specs(base / "SPRITES.md")
+
+    pygame.init()
+    for name in specs:
+        out = base / name
+        generate_sprite(name[:-4], out, specs)
+    pygame.quit()
+
+
+if __name__ == "__main__":
+    generate_all()

--- a/super_pole_position/physics/car.py
+++ b/super_pole_position/physics/car.py
@@ -24,10 +24,12 @@ class Car:
         self.speed = speed
         self.acceleration = 2.0
         # Two gear ratios: index 0=LOW, 1=HIGH
-        self.gear_max = [8.0, 19.0]
+        # Adjusted top speed for closer arcade feel
+        self.gear_max = [8.0, 22.0]
         self.gear = 0
         self.max_speed = self.gear_max[-1]
-        self.turn_rate = 2.0  # rad/sec
+        # Slightly quicker steering for responsive handling
+        self.turn_rate = 2.5  # rad/sec
         self.shift_count = 0
         # If True speed is not clamped by gear ratios (Hyper mode)
         self.unlimited = False

--- a/super_pole_position/physics/traffic_car.py
+++ b/super_pole_position/physics/traffic_car.py
@@ -18,6 +18,7 @@ class TrafficCar(Car):
     def __init__(self, x=0.0, y=0.0, target_speed=5.0):
         super().__init__(x=x, y=y)
         self.target_speed = target_speed
+        self.turn_rate = 1.0
 
     def policy(self, track=None):
         """Return throttle, brake, steer toward the track centerline."""
@@ -29,6 +30,6 @@ class TrafficCar(Car):
         if track is not None:
             target_y = track.y_at(self.x)
             offset = target_y - self.y
-            steer = max(-1.0, min(1.0, offset * 0.1))
+            steer = max(-1.0, min(1.0, offset * 0.05))
 
         return throttle, brake, steer

--- a/super_pole_position/ui/sprites.py
+++ b/super_pole_position/ui/sprites.py
@@ -99,4 +99,29 @@ def load_sprite(name: str, ascii_art: list[str] | None = None) -> "pygame.Surfac
             return pygame.image.load(str(path))
         except Exception:
             return ascii_surface(ascii_art or [])
+    else:
+        # attempt to generate placeholder sprite on the fly
+        gen = path.parent / "generate_placeholders.py"
+        if gen.exists():
+            try:
+                import importlib.util
+
+                spec = importlib.util.spec_from_file_location("placeholder_gen", gen)
+                if spec and spec.loader:
+                    mod = importlib.util.module_from_spec(spec)
+                    spec.loader.exec_module(mod)
+                    if hasattr(mod, "generate_all"):
+                        mod.generate_all(path.parent)
+                    elif hasattr(mod, "generate_sprite"):
+                        size_map = getattr(mod, "_parse_sprite_specs", lambda _: {})(
+                            path.parent / "SPRITES.md"
+                        )
+                        mod.generate_sprite(name, path, size_map)
+            except Exception:
+                pass
+            if path.exists() and path.stat().st_size > 0:
+                try:
+                    return pygame.image.load(str(path))
+                except Exception:
+                    pass
     return ascii_surface(ascii_art or [])


### PR DESCRIPTION
## Summary
- improve placeholder generator using specs from `SPRITES.md`
- generate missing sprites from loader via `importlib`
- keep higher top speed and quick steering for arcade feel
- tune traffic car steering

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685779437d5c83249519b06293f22403