### PR TITLE
Remove simpleaudio and rely on pygame mixer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
 
 [project.optional-dependencies]
 graphics = ["pygame"]
-audio = ["simpleaudio"]
 ai = ["torch", "transformers"]
 dev = ["pytest", "pytest-cov", "coverage", "pytest-timeout"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ gymnasium
 numpy
 pyyaml
 pygame
-simpleaudio
 torch
 transformers
 pytest

--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -20,14 +20,10 @@ from pathlib import Path
 
 try:
     import pygame  # optional dependency for graphics
-    from pygame import mixer as pg_mixer  # audio fallback via pygame
+    from pygame import mixer as pg_mixer  # audio via pygame
 except Exception:  # pragma: no cover - optional dependency may be missing
     pygame = None
     pg_mixer = None
-try:
-    import simpleaudio as sa
-except Exception:  # pragma: no cover - optional dependency
-    sa = None
 
 from ..physics.car import Car
 from ..physics.track import Track
@@ -196,31 +192,10 @@ class PolePositionEnv(gym.Env):
 
         self.audio_stream = None
         base = Path(__file__).resolve().parent.parent / "assets" / "audio"
-        if sa is not None:
+        if pg_mixer is not None:
             try:
-                # Audio files are expected under assets/audio/ but may be absent
-                # in open-source releases.  They will be provided separately.
-                self.crash_wave = sa.WaveObject.from_wave_file(str(base / "crash.wav"))
-                self.prepare_wave = sa.WaveObject.from_wave_file(
-                    str(base / "prepare.wav")
-                )
-                self.final_lap_wave = sa.WaveObject.from_wave_file(
-                    str(base / "final_lap.wav")
-                )
-                self.goal_wave = sa.WaveObject.from_wave_file(str(base / "goal.wav"))
-                self.bgm_wave = sa.WaveObject.from_wave_file(
-                    str(base / "namco_theme.wav")
-                )
-            except Exception:  # pragma: no cover - file missing
-                # Placeholders handle missing WAVs during tests
-                self.crash_wave = None
-                self.prepare_wave = None
-                self.final_lap_wave = None
-                self.goal_wave = None
-                self.bgm_wave = None
-        elif pg_mixer is not None:
-            try:
-                pg_mixer.init()
+                if not pg_mixer.get_init():
+                    pg_mixer.init()
                 pg_mixer.music.set_volume(self.audio_volume)
                 self.crash_wave = pg_mixer.Sound(str(base / "crash.wav"))
                 self.crash_wave.set_volume(self.audio_volume)
@@ -753,7 +728,7 @@ class PolePositionEnv(gym.Env):
 
     def _play_binaural_audio(self, duration=0.1, sample_rate=44100):
         """Generate stereo engine audio with basic position-based panning."""
-        if sa is None and pg_mixer is None:
+        if pg_mixer is None:
             return
 
         t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
@@ -790,29 +765,21 @@ class PolePositionEnv(gym.Env):
             except Exception:
                 pass
 
-        if sa is not None:
-            self.audio_stream = sa.play_buffer(
-                waveform_int16,
-                num_channels=2,
-                bytes_per_sample=2,
-                sample_rate=sample_rate,
-            )
-        elif pg_mixer is not None:
-            if not pg_mixer.get_init():
-                try:
-                    pg_mixer.init(frequency=sample_rate, channels=2)
-                except Exception:
-                    return
-            sound = pygame.sndarray.make_sound(waveform_int16)
-            channel = sound.play()
-            if channel:
-                channel.set_volume(self.audio_volume, self.audio_volume)
-            self.audio_stream = channel
+        if not pg_mixer.get_init():
+            try:
+                pg_mixer.init(frequency=sample_rate, channels=2)
+            except Exception:
+                return
+        sound = pygame.sndarray.make_sound(waveform_int16)
+        channel = sound.play()
+        if channel:
+            channel.set_volume(self.audio_volume, self.audio_volume)
+        self.audio_stream = channel
 
     def _play_crash_audio(self) -> None:
         """Play crash sound effect once."""
 
-        if sa is None and pg_mixer is None:
+        if pg_mixer is None:
             return
         if self.crash_wave is None:
             return
@@ -822,7 +789,7 @@ class PolePositionEnv(gym.Env):
     def _play_prepare_voice(self) -> None:
         """Play the 'Get Ready' voice sample."""
 
-        if sa is None and pg_mixer is None:
+        if pg_mixer is None:
             return
         if self.prepare_wave is None:
             return
@@ -836,20 +803,17 @@ class PolePositionEnv(gym.Env):
 
         if os.environ.get("MUTE_BGM", "0") == "1":
             return
-        if sa is None and pg_mixer is None:
-            return
-        if self.bgm_wave is None:
+        if pg_mixer is None or self.bgm_wave is None:
             return
         try:
-            # simpleaudio lacks looping support; play once per reset
-            self.bgm_wave.play()
+            self.bgm_wave.play(loops=-1)
         except Exception:  # pragma: no cover
             pass
 
     def _play_final_lap_voice(self) -> None:
         """Play 'Final Lap' voice sample."""
 
-        if sa is None and pg_mixer is None:
+        if pg_mixer is None:
             return
         if self.final_lap_wave is None:
             return
@@ -861,7 +825,7 @@ class PolePositionEnv(gym.Env):
     def _play_goal_voice(self) -> None:
         """Play 'Goal' voice sample when race finishes."""
 
-        if sa is None and pg_mixer is None:
+        if pg_mixer is None:
             return
         if self.goal_wave is None:
             return
@@ -873,43 +837,24 @@ class PolePositionEnv(gym.Env):
     def _play_panned_wave(self, wave_obj, pan: float) -> None:
         """Play ``wave_obj`` panned left/right based on ``pan`` (-1..1)."""
 
-        if sa is None and pg_mixer is None:
+        if pg_mixer is None:
             return
         if wave_obj is None:
             return
         try:
-            if sa is not None and hasattr(wave_obj, "audio_data"):
-                audio = np.frombuffer(wave_obj.audio_data, dtype=np.int16)
-                if wave_obj.num_channels == 1:
-                    audio = np.repeat(audio, 2)
-                audio = audio.reshape(-1, 2)
-                pan = max(-1.0, min(1.0, pan))
-                left_gain = 1.0 - max(0.0, pan)
-                right_gain = 1.0 + min(0.0, pan)
-                audio[:, 0] = (audio[:, 0] * left_gain).astype(np.int16)
-                audio[:, 1] = (audio[:, 1] * right_gain).astype(np.int16)
-                if self.audio_stream is not None:
-                    self.audio_stream.stop()
-                self.audio_stream = sa.play_buffer(
-                    audio,
-                    num_channels=2,
-                    bytes_per_sample=wave_obj.bytes_per_sample,
-                    sample_rate=wave_obj.sample_rate,
+            if not pg_mixer.get_init():
+                try:
+                    pg_mixer.init()
+                except Exception:
+                    return
+            pan = max(-1.0, min(1.0, pan))
+            channel = wave_obj.play()
+            if channel:
+                channel.set_volume(
+                    self.audio_volume * (1.0 - max(0.0, pan)),
+                    self.audio_volume * (1.0 + min(0.0, pan)),
                 )
-            elif pg_mixer is not None:
-                if not pg_mixer.get_init():
-                    try:
-                        pg_mixer.init()
-                    except Exception:
-                        return
-                pan = max(-1.0, min(1.0, pan))
-                channel = wave_obj.play()
-                if channel:
-                    channel.set_volume(
-                        self.audio_volume * (1.0 - max(0.0, pan)),
-                        self.audio_volume * (1.0 + min(0.0, pan)),
-                    )
-                self.audio_stream = channel
+            self.audio_stream = channel
         except Exception:  # pragma: no cover
             try:
                 wave_obj.play()
@@ -919,7 +864,7 @@ class PolePositionEnv(gym.Env):
     def _play_skid_audio(self) -> None:
         """Play short noise burst when skidding with stereo pan."""
 
-        if sa is None and pg_mixer is None:
+        if pg_mixer is None:
             return
         duration = 0.2
         sample_rate = 44100
@@ -936,21 +881,13 @@ class PolePositionEnv(gym.Env):
                 self.audio_stream.stop()
             except Exception:
                 pass
-        if sa is not None:
-            self.audio_stream = sa.play_buffer(
-                waveform_int16,
-                num_channels=2,
-                bytes_per_sample=2,
-                sample_rate=sample_rate,
-            )
-        elif pg_mixer is not None:
-            if not pg_mixer.get_init():
-                try:
-                    pg_mixer.init(frequency=sample_rate, channels=2)
-                except Exception:
-                    return
-            sound = pygame.sndarray.make_sound(waveform_int16)
-            self.audio_stream = sound.play()
+        if not pg_mixer.get_init():
+            try:
+                pg_mixer.init(frequency=sample_rate, channels=2)
+            except Exception:
+                return
+        sound = pygame.sndarray.make_sound(waveform_int16)
+        self.audio_stream = sound.play()
 
     def close(self):
         """Clean up resources like audio streams."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,35 +16,40 @@ import types
 try:
     import pygame  # type: ignore
 except Exception:  # pragma: no cover - optional
-    pygame = types.SimpleNamespace(display=types.SimpleNamespace(init=lambda *a, **k: None))
+    pygame = types.SimpleNamespace(
+        display=types.SimpleNamespace(init=lambda *a, **k: None),
+        mixer=types.SimpleNamespace(),
+        sndarray=types.SimpleNamespace(),
+    )
 
 os.environ.setdefault("FAST_TEST", "1")
 os.environ["ALLOW_NET"] = "0"
 os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
 
-class _DummyWave:
-    bytes_per_sample = 2
-    num_channels = 2
-    sample_rate = 44100
-    audio_data = b""
 
-    @staticmethod
-    def from_wave_file(*args, **kwargs):
-        return _DummyWave()
+class _DummyChannel:
+    def stop(self):
+        pass
+
+    def set_volume(self, *args, **kwargs):
+        pass
+
+
+class _DummySound:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def set_volume(self, *args, **kwargs):
+        pass
 
     def play(self, *args, **kwargs):
-        return None
+        return _DummyChannel()
 
-def _play_buffer(*args, **kwargs):
-    class _Dummy:
-        def stop(self):
-            pass
-    return _Dummy()
-
-sys.modules["simpleaudio"] = types.SimpleNamespace(
-    WaveObject=_DummyWave,
-    play_buffer=_play_buffer,
-)
+pygame.mixer.init = lambda *a, **k: None
+pygame.mixer.get_init = lambda: True
+pygame.mixer.Sound = lambda *a, **k: _DummySound()
+pygame.mixer.music = types.SimpleNamespace(set_volume=lambda *a, **k: None)
+pygame.sndarray.make_sound = lambda *a, **k: _DummySound()
 
 pygame.display.init = lambda *args, **kwargs: None
 


### PR DESCRIPTION
## Summary
- drop `simpleaudio` fallback
- update audio helpers to use `pygame.mixer`
- adjust dummy audio helpers in tests
- remove `simpleaudio` from optional dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68579ff1dcbc832482adf4f5f99bed11