### PR TITLE
Improve slipstream timing

### DIFF
--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -489,7 +489,7 @@ class PolePositionEnv(gym.Env):
             self.skid_timer = 1.0
             self._play_skid_audio()
 
-        # Slipstream boost behind another car
+        # Slipstream boost behind another car requires staying close
         slip = False
         for other in [self.cars[1]] + self.traffic:
             dx = (other.x - self.cars[0].x + self.track.width) % self.track.width
@@ -499,12 +499,13 @@ class PolePositionEnv(gym.Env):
                 break
         if slip:
             self.slipstream_timer += dt
-            if self.slipstream_timer >= (1.0 / self.metadata.get("render_fps", 60)):
+            if self.slipstream_timer >= 0.5:
                 self.cars[0].speed = min(
-                    self.cars[0].speed * 1.1,
-                    self.cars[0].gear_max[self.cars[0].gear],
+                    self.cars[0].speed * 1.05,
+                    self.cars[0].gear_max[self.cars[0].gear] + 5,
                 )
                 self.slipstream_frames += 1
+                self.slipstream_timer = 0.0
         else:
             self.slipstream_timer = 0.0
 

--- a/tests/test_slipstream_boost.py
+++ b/tests/test_slipstream_boost.py
@@ -22,10 +22,14 @@ def test_slipstream_boost():
     env.reset()
     env.start_timer = 0
     lead = env.traffic[0]
+    from super_pole_position.physics.traffic_car import TrafficCar
+    env.traffic[0] = TrafficCar(x=lead.x, y=lead.y, target_speed=5.0)
+    lead = env.traffic[0]
     env.cars[0].y = lead.y
     env.cars[0].x = lead.x - 2
     env.cars[0].speed = lead.speed = 5.0
     env.cars[0].gear = 1
-    env.step((False, False, 0.0))
+    for _ in range(40):
+        env.step((False, False, 0.0))
     assert env.cars[0].speed > 5.0
     env.close()


### PR DESCRIPTION
## Summary
- delay slipstream boost until trailing for half a second
- adjust test for new slipstream behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6857a5a768908324b5f134b166df60e3