### PR TITLE
Improve test skipping for missing deps

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,9 @@ Description: Test suite for conftest.
 
 import pytest  # noqa: F401
 
+# Skip the entire suite if gymnasium is unavailable
+pytest.importorskip("gymnasium")
+
 import os
 import sys
 import types


### PR DESCRIPTION
## Summary
- skip the test suite if `gymnasium` is not available

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857be6a51988324982e792119b97736