### PR TITLE
Clean up ruff issues

### DIFF
--- a/examples/animated_sprite.py
+++ b/examples/animated_sprite.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Simple animated sprite movement demo using Pygame 2."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import List

--- a/super_pole_position/agents/__init__.py
+++ b/super_pole_position/agents/__init__.py
@@ -3,13 +3,9 @@
 # Copyright (c) 2025 MIND INTERFACES, INC. All rights reserved.
 # Licensed under the MIT License.
 
-"""
-__init__.py
-Description: Module for Super Pole Position.
-"""
-
-
 """Agent implementations and controller helpers."""
 
 from .keyboard_agent import KeyboardAgent
+
+__all__ = ["KeyboardAgent"]
 

--- a/super_pole_position/config.py
+++ b/super_pole_position/config.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Configuration utilities for arcade parity tweaks. 🎛️"""
+
+from __future__ import annotations
 
 from pathlib import Path
 from typing import Any

--- a/super_pole_position/physics/track_curve.py
+++ b/super_pole_position/physics/track_curve.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Helpers for centerline curve interpolation."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 import math

--- a/super_pole_position/physics/track_info.py
+++ b/super_pole_position/physics/track_info.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Track information utilities."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 import json

--- a/super_pole_position/server/sync.py
+++ b/super_pole_position/server/sync.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Background scoreboard sync service."""
+
+from __future__ import annotations
 
 import json
 import os

--- a/super_pole_position/ui/arcade.py
+++ b/super_pole_position/ui/arcade.py
@@ -20,6 +20,13 @@ from typing import Dict
 
 
 from ..config import load_parity_config
+from .sprites import (
+    BILLBOARD_ART,
+    CAR_ART,
+    EXPLOSION_FRAMES,
+    ascii_surface,
+)
+from ..evaluation.scores import load_scores
 
 
 _AUDIO_CFG = load_parity_config()
@@ -64,15 +71,6 @@ def _load_config() -> dict:
 _PARITY_CFG = _load_config()
 SCANLINE_SPACING = int(_PARITY_CFG.get("scanline_spacing", 2))
 SCANLINE_ALPHA = int(_PARITY_CFG.get("scanline_alpha", 40))
-
-from .sprites import (
-    BILLBOARD_ART,
-    CAR_ART,
-    EXPLOSION_FRAMES,
-    ascii_surface,
-    load_sprite,
-)
-from ..evaluation.scores import load_scores
 
 try:
     HIGH_SCORE = max((s["score"] for s in load_scores(None)), default=0)

--- a/super_pole_position/ui/sprites.py
+++ b/super_pole_position/ui/sprites.py
@@ -118,8 +118,6 @@ def load_sprite(name: str, ascii_art: list[str] | None = None) -> "pygame.Surfac
         gen = path.parent / "generate_placeholders.py"
         if gen.exists():
             try:
-                import importlib.util
-
                 spec = importlib.util.spec_from_file_location("placeholder_gen", gen)
                 if spec and spec.loader:
                     mod = importlib.util.module_from_spec(spec)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,6 @@ Description: Test suite for conftest.
 import pytest  # noqa: F401
 
 import os
-import sys
 import types
 try:
     import pygame  # type: ignore

--- a/tests/test_trackcurve.py
+++ b/tests/test_trackcurve.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 """Tests for TrackCurve helper."""
 
-import math
 import pytest
 
 from super_pole_position.physics.track_curve import TrackCurve


### PR DESCRIPTION
## Summary
- fix ruff warnings across the codebase
- remove unused imports in tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_6857be6a51988324982e792119b97736