### PR TITLE
Implement simple background renderer

### DIFF
--- a/src/render/background.py
+++ b/src/render/background.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pygame
+
+
+class Background:
+    """Simple parallax sky and mountain renderer."""
+
+    def __init__(self, assets_dir: Path, no_bg: bool = False) -> None:
+        self.no_bg = no_bg
+        if no_bg:
+            self.mt = None
+            self.clouds = None
+        else:
+            try:
+                self.mt = pygame.image.load(assets_dir / "mt_fuji.png").convert()
+            except Exception:
+                self.mt = None
+            try:
+                self.clouds = pygame.image.load(assets_dir / "clouds.png").convert_alpha()
+            except Exception:
+                self.clouds = None
+
+    # ------------------------------------------------------------------
+    def draw(self, surface: pygame.Surface, player_x: float, curvature: float) -> None:
+        """Draw the sky background relative to ``player_x`` and ``curvature``."""
+
+        if self.no_bg or not pygame:
+            return
+
+        if self.clouds:
+            w = self.clouds.get_width()
+            offset = int((player_x * 0.2) % w)
+            for x in (-offset, -offset + w, -offset + 2 * w):
+                surface.blit(self.clouds, (x, 20))
+
+        if self.mt:
+            mt_x = 128 - self.mt.get_width() // 2 + int(curvature * 30)
+            surface.blit(self.mt, (mt_x, 40))
+
+"""
+── Panda3D snippet (grid_leader/sky.py) ───────────────────────────────
+clouds.setTexOffset(u, player.x*0.0002)
+mt_fuji.setX(curvature*30)
+
+# Pygame translation replicates same offsets by per-frame blit positions.
+"""

--- a/tests/render/test_background.py
+++ b/tests/render/test_background.py
@@ -1,0 +1,14 @@
+import pathlib
+
+import pygame
+
+from src.render.background import Background
+
+pygame.display.init()
+pygame.display.set_mode((1, 1))
+
+
+def test_no_bg_flag() -> None:
+    bg = Background(pathlib.Path("assets"), no_bg=True)
+    surf = pygame.Surface((256, 224))
+    bg.draw(surf, player_x=1000, curvature=0.1)


### PR DESCRIPTION
## Summary
- add `Background` renderer for parallax clouds and Mount Fuji
- support `no_bg` flag and mount in tests
- test that no background mode draws without crashing

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858093641308324b87b3c1d0c80b90f