### PR TITLE
Improve renderer road details

### DIFF
--- a/tests/render/test_center_stripe.py
+++ b/tests/render/test_center_stripe.py
@@ -1,0 +1,19 @@
+import types
+import pytest
+pygame = pytest.importorskip("pygame")
+from src.render.pseudo3d_renderer import Renderer, WIDTH, HEIGHT
+
+
+def test_center_stripe_drawn() -> None:
+    pygame.display.init()
+    pygame.display.set_mode((1, 1))
+    env = types.SimpleNamespace(
+        cars=[types.SimpleNamespace(speed=100.0, x=0.0)],
+        track=types.SimpleNamespace(curvature_at=lambda x: 0.0),
+        sprites=[],
+    )
+    r = Renderer(None)
+    r.draw(env)
+    color = r.surface.get_at((WIDTH // 2, HEIGHT - 2))[:3]
+    assert color != (60, 60, 60)
+    pygame.display.quit()


### PR DESCRIPTION
## Summary
- animate dashed center stripe on the road
- fade sprites near the horizon
- cover center stripe drawing with a test

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68581de807508324879c6a9279fd49eb