### PR TITLE
Add player name support

### DIFF
--- a/PROGRESS_ARCADE_PARITY.md
+++ b/PROGRESS_ARCADE_PARITY.md
@@ -20,5 +20,6 @@
 - [x] Stereo engine audio panned by car position
 - [x] Minimal SFX manager with chiptune placeholders
 - [x] Lap times posted to scoreboard API
+- [x] Player name recorded in high-score table
 
 🎉 All core arcade mechanics implemented! 🏁

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ python press_start.py
 spp qualify --agent null --track fuji
 # try the new curved Fuji circuit
 spp qualify --agent null --track fuji_curve
+# record scores under your initials
+spp race --player AAA
 ```
 ![](docs.gif)
 
@@ -174,6 +176,7 @@ python -m super_pole_position.server.api
 ```
 
 Use `GET /scores` to list results and `POST /scores` to submit new scores.
+Set `--player AAA` when racing to record your initials.
 
 To clear your local high-score table run:
 

--- a/super_pole_position/cli.py
+++ b/super_pole_position/cli.py
@@ -43,6 +43,7 @@ def main() -> None:
     q.add_argument("--track", default="fuji")
     q.add_argument("--render", action="store_true")
     q.add_argument("--mute-bgm", action="store_true", help="Disable background music")
+    q.add_argument("--player", default="PLAYER", help="Name for score entry")
     q.add_argument(
         "--virtual-joystick",
         action="store_true",
@@ -54,6 +55,7 @@ def main() -> None:
     r.add_argument("--track", default="fuji")
     r.add_argument("--render", action="store_true")
     r.add_argument("--mute-bgm", action="store_true", help="Disable background music")
+    r.add_argument("--player", default="PLAYER", help="Name for score entry")
     r.add_argument(
         "--virtual-joystick",
         action="store_true",
@@ -116,7 +118,10 @@ def main() -> None:
             args.track = cfg.get("track", args.track)
             os.environ["AUDIO"] = "1" if cfg.get("audio", True) else "0"
         env = PolePositionEnv(
-            render_mode="human", mode="qualify", track_name=args.track
+            render_mode="human",
+            mode="qualify",
+            track_name=args.track,
+            player_name=args.player,
         )
         agent_cls = AGENT_MAP.get(args.agent, NullAgent)
         agent = agent_cls()
@@ -129,7 +134,7 @@ def main() -> None:
         )
         update_scores(
             Path(__file__).parent / "evaluation" / "scores.json",
-            args.agent,
+            args.player,
             int(env.score),
         )
         env.close()
@@ -156,7 +161,12 @@ def main() -> None:
                 return
             args.track = cfg.get("track", args.track)
             os.environ["AUDIO"] = "1" if cfg.get("audio", True) else "0"
-        env = PolePositionEnv(render_mode="human", mode="race", track_name=args.track)
+        env = PolePositionEnv(
+            render_mode="human",
+            mode="race",
+            track_name=args.track,
+            player_name=args.player,
+        )
         agent_cls = AGENT_MAP.get(args.agent, NullAgent)
         agent = agent_cls()
         run_episode(env, (agent, agent))
@@ -168,7 +178,7 @@ def main() -> None:
         )
         update_scores(
             Path(__file__).parent / "evaluation" / "scores.json",
-            args.agent,
+            args.player,
             int(env.score),
         )
         env.close()

--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -71,6 +71,7 @@ class PolePositionEnv(gym.Env):
         mode: str = "race",
         track_name: str | None = None,
         hyper: bool = False,
+        player_name: str = "PLAYER",
     ) -> None:
         """Create a Pole Position environment.
 
@@ -78,12 +79,14 @@ class PolePositionEnv(gym.Env):
         :param mode: ``race`` or ``qualify``.
         :param track_name: Optional track to load.
         :param hyper: If ``True`` doubles gear limits for extreme speed.
+        :param player_name: Name recorded in the high-score table.
         """
 
         super().__init__()
         self.render_mode = render_mode
         self.mode = mode
         self.hyper = hyper
+        self.player_name = player_name
 
         self.time_limit = 90.0 if self.mode == "race" else 73.0
         self.traffic_count = 7 if self.mode == "race" else 0
@@ -572,7 +575,9 @@ class PolePositionEnv(gym.Env):
             self.time_extend_flash = 2.0
             print(f"[ENV] Completed lap {self.lap} in {self.last_lap_time:.2f}s", flush=True)
             try:
-                submit_score_http("lap", int(self.last_lap_time * 1000))
+                submit_score_http(
+                    f"{self.player_name}_lap", int(self.last_lap_time * 1000)
+                )
             except Exception:
                 pass
             if self.mode == "qualify":
@@ -643,7 +648,7 @@ class PolePositionEnv(gym.Env):
                 pass
             self.score += int(self.remaining_time * 5)
             try:
-                submit_score_http("final", int(self.score))
+                submit_score_http(self.player_name, int(self.score))
             except Exception:
                 pass
             print("[ENV] Race finished", flush=True)

--- a/tests/test_cli_player_name.py
+++ b/tests/test_cli_player_name.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Ensure CLI forwards --player to env and scoreboard."""
+
+import sys
+from pathlib import Path
+
+import pytest  # noqa: F401
+
+from super_pole_position import cli
+
+
+def test_cli_player_name(monkeypatch):
+    recorded = {}
+
+    class DummyEnv:
+        def __init__(self, *_, player_name: str = "", **__):  # type: ignore
+            recorded["name"] = player_name
+            self.score = 0
+
+        def close(self):
+            pass
+
+    monkeypatch.setitem(sys.modules, "pygame", None)
+    monkeypatch.setattr(cli, "run_episode", lambda env, agents: None)
+    monkeypatch.setattr(cli, "update_leaderboard", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "summary", lambda env: {})
+    names: list[str] = []
+
+    def fake_update_scores(file: Path, name: str, score: int) -> None:
+        names.append(name)
+
+    monkeypatch.setattr(cli, "update_scores", fake_update_scores)
+    monkeypatch.setattr(cli, "PolePositionEnv", DummyEnv)
+    monkeypatch.setattr(sys, "argv", ["spp", "race", "--player", "AAA"])
+    monkeypatch.setenv("FAST_TEST", "1")
+
+    cli.main()
+    assert recorded.get("name") == "AAA"
+    assert names == ["AAA"]


### PR DESCRIPTION
## Summary
- allow setting a player name for hi-score entries
- pass `--player` from CLI to the environment and scoreboard
- document the feature in the README and progress log
- test that the CLI forwards `--player`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685825cd6ac483248282da5f7788e314