### PR TITLE
Enhance arcade parity with high-score overlay

### DIFF
--- a/PROGRESS_ARCADE_PARITY.md
+++ b/PROGRESS_ARCADE_PARITY.md
@@ -20,5 +20,6 @@
 - [x] Stereo engine audio panned by car position
 - [x] Minimal SFX manager with chiptune placeholders
 - [x] Lap times posted to scoreboard API
+- [x] Post-race scoreboard overlay displays top five scores
 
 🎉 All core arcade mechanics implemented! 🏁

--- a/super_pole_position/ui/arcade.py
+++ b/super_pole_position/ui/arcade.py
@@ -611,6 +611,17 @@ class Pseudo3DRenderer:
             mx = width // 2 - msg.get_width() // 2
             my = height // 2 - msg.get_height() // 2
             surface.blit(msg, (mx, my))
+            if env.game_message in {"FINISHED!", "TIME UP!"}:
+                try:
+                    table = load_scores(None)
+                except Exception:
+                    table = []
+                for i, entry in enumerate(table[:5]):
+                    line = f"{i+1}. {entry['name']} {entry['score']:05d}"
+                    txt = self.start_font.render(line, True, (255, 255, 255))
+                    tx = width // 2 - txt.get_width() // 2
+                    ty = my + 40 + i * 20
+                    surface.blit(txt, (tx, ty))
 
         if self.start_font and getattr(env, "time_extend_flash", 0) > 0:
             text = self.start_font.render("EXTENDED TIME", True, (255, 255, 0))

--- a/tests/ui/test_scoreboard_overlay.py
+++ b/tests/ui/test_scoreboard_overlay.py
@@ -1,0 +1,50 @@
+import json
+import os
+import types
+import pygame
+
+pygame = pygame  # ensure import before pytest skip
+from super_pole_position.ui.arcade import ArcadeRenderer
+from super_pole_position.evaluation import scores
+
+
+def test_scoreboard_overlay(tmp_path):
+    pygame.display.init()
+    pygame.font.init()
+    screen = pygame.display.set_mode((160, 120))
+
+    scoreboard = tmp_path / "scores.json"
+    scoreboard.write_text(json.dumps({"scores": [{"name": "AAA", "score": 500}]}))
+    os.environ["SPP_SCORES"] = str(scoreboard)
+    os.environ["AUDIO"] = "0"
+
+    renderer = ArcadeRenderer(screen)
+    dummy_sound = types.SimpleNamespace(play=lambda *a, **k: None)
+    renderer.engine_sound = dummy_sound
+    renderer.skid_sound = dummy_sound
+    renderer.crash_sound = dummy_sound
+    renderer.channels = [
+        types.SimpleNamespace(play=lambda *a, **k: None, get_busy=lambda: False)
+        for _ in range(3)
+    ]
+    env = types.SimpleNamespace(
+        cars=[types.SimpleNamespace(x=0.0, y=0.0, speed=0.0, gear=0)],
+        track=types.SimpleNamespace(angle_at=lambda x: 0.0, width=160, height=120, progress=lambda c: 0.0),
+        start_phase="",
+        current_step=60,
+        message_timer=1.0,
+        game_message="FINISHED!",
+        remaining_time=0.0,
+        lap_timer=0.0,
+        last_lap_time=None,
+        lap_flash=0.0,
+        time_extend_flash=0.0,
+        lap=0,
+        score=100,
+        high_score=100,
+        crash_timer=0.0,
+    )
+    renderer.draw(env)
+    color = screen.get_at((80, 80))[:3]
+    assert color != (0, 0, 0)
+    pygame.display.quit()


### PR DESCRIPTION
## Summary
- display scoreboard after race finish
- document scoreboard overlay in progress log
- add test for scoreboard overlay

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685825cd6ac483248282da5f7788e314