### PR TITLE
Add safe episode runner

### DIFF
--- a/press_start.py
+++ b/press_start.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from super_pole_position.agents.keyboard_agent import KeyboardAgent
 from super_pole_position.envs.pole_position import PolePositionEnv
 from super_pole_position.evaluation.metrics import summary
-from super_pole_position.matchmaking.arena import run_episode
+from super_pole_position.utils import safe_run_episode
 
 
 INTRO = """
@@ -36,7 +36,11 @@ def main() -> None:
     # 🚗 Prepare the track and cars
     # Create a race-ready environment. 🏆
 
-    env = PolePositionEnv(render_mode="human", mode="race", track_name="fuji")
+    try:
+        env = PolePositionEnv(render_mode="human", mode="race", track_name="fuji")
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"env error: {exc}", flush=True)
+        return
     # KeyboardAgent lets you take control of the action. 🎮
     agent = KeyboardAgent()
 
@@ -44,7 +48,7 @@ def main() -> None:
     play_again = True
     while play_again:
         env.reset()
-        run_episode(env, (agent, agent))
+        safe_run_episode(env, (agent, agent))
         print(summary(env))
         ans = input("Race again? [y/N] ")
         play_again = ans.strip().lower().startswith("y")

--- a/super_pole_position/cli.py
+++ b/super_pole_position/cli.py
@@ -22,6 +22,7 @@ from .agents.keyboard_agent import KeyboardAgent
 
 from .envs.pole_position import PolePositionEnv
 from .matchmaking.arena import run_episode, update_leaderboard
+from .utils import safe_run_episode
 from .evaluation.metrics import summary
 from .evaluation.scores import load_scores, reset_scores, update_scores
 
@@ -125,7 +126,7 @@ def main() -> None:
         )
         agent_cls = AGENT_MAP.get(args.agent, NullAgent)
         agent = agent_cls()
-        run_episode(env, (agent, agent))
+        safe_run_episode(env, (agent, agent))
         metrics = summary(env)
         update_leaderboard(
             Path(__file__).parent / "evaluation" / "leaderboard.json",
@@ -169,7 +170,7 @@ def main() -> None:
         )
         agent_cls = AGENT_MAP.get(args.agent, NullAgent)
         agent = agent_cls()
-        run_episode(env, (agent, agent))
+        safe_run_episode(env, (agent, agent))
         metrics = summary(env)
         update_leaderboard(
             Path(__file__).parent / "evaluation" / "leaderboard.json",

--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -751,7 +751,7 @@ class PolePositionEnv(gym.Env):
 
     def _play_binaural_audio(self, duration=0.1, sample_rate=44100):
         """Generate stereo engine audio with per-player panning."""
-        if pg_mixer is None:
+        if pg_mixer is None or pygame is None:
             return
 
         t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)

--- a/super_pole_position/utils/__init__.py
+++ b/super_pole_position/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility helpers for SUPER-POLE-POSITION."""
+
+from .math import factorial
+from .logging import safe_run_episode
+
+__all__ = ["factorial", "safe_run_episode"]

--- a/super_pole_position/utils/logging.py
+++ b/super_pole_position/utils/logging.py
@@ -1,0 +1,18 @@
+"""Logging helpers for SUPER-POLE-POSITION."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from ..agents.base_llm_agent import BaseLLMAgent
+from ..envs.pole_position import PolePositionEnv
+from ..matchmaking.arena import run_episode
+
+
+def safe_run_episode(env: PolePositionEnv, agents: Tuple[BaseLLMAgent, BaseLLMAgent]) -> None:
+    """Run an episode and log any exception."""
+    try:
+        run_episode(env, agents)
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"episode error: {exc}", flush=True)
+


### PR DESCRIPTION
## Summary
- log exceptions during gameplay with `safe_run_episode`
- use `safe_run_episode` in press_start and CLI entry points
- guard audio playback when `pygame` is missing
- export helper from utils

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68585273c0e08324aa3d8c316eee07ec