### PR TITLE
Add basic error logging to game launcher

### DIFF
--- a/press_start.py
+++ b/press_start.py
@@ -9,6 +9,11 @@ from super_pole_position.agents.keyboard_agent import KeyboardAgent
 from super_pole_position.envs.pole_position import PolePositionEnv
 from super_pole_position.evaluation.metrics import summary
 from super_pole_position.matchmaking.arena import run_episode
+import logging
+
+
+logging.basicConfig(level=logging.ERROR)
+logger = logging.getLogger(__name__)
 
 
 INTRO = """
@@ -36,16 +41,27 @@ def main() -> None:
     # 🚗 Prepare the track and cars
     # Create a race-ready environment. 🏆
 
-    env = PolePositionEnv(render_mode="human", mode="race", track_name="fuji")
+    try:
+        env = PolePositionEnv(
+            render_mode="human", mode="race", track_name="fuji"
+        )
+    except Exception as exc:  # pragma: no cover - startup errors
+        logger.exception("Failed to create environment: %s", exc)
+        return
+
     # KeyboardAgent lets you take control of the action. 🎮
     agent = KeyboardAgent()
 
     # 🔁 Allow multiple races without closing the window
     play_again = True
     while play_again:
-        env.reset()
-        run_episode(env, (agent, agent))
-        print(summary(env))
+        try:
+            env.reset()
+            run_episode(env, (agent, agent))
+            print(summary(env))
+        except Exception as exc:
+            logger.exception("Runtime error: %s", exc)
+            break
         ans = input("Race again? [y/N] ")
         play_again = ans.strip().lower().startswith("y")
 


### PR DESCRIPTION
## Summary
- add `logging` setup in `press_start.py`
- catch and log exceptions when creating the environment or running the race loop

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q` *(fails: could not import 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_68585273c0e08324aa3d8c316eee07ec