### PR TITLE
Add outro highscore display

### DIFF
--- a/super_pole_position/cli.py
+++ b/super_pole_position/cli.py
@@ -20,11 +20,12 @@ from .agents.openai_agent import OpenAIAgent
 from .agents.mistral_agent import MistralAgent
 from .agents.keyboard_agent import KeyboardAgent
 
-from .envs.pole_position import PolePositionEnv
+from .envs.pole_position import PolePositionEnv, FAST_TEST
 from .matchmaking.arena import run_episode, update_leaderboard
 from .utils import safe_run_episode
 from .evaluation.metrics import summary
 from .evaluation.scores import load_scores, reset_scores, update_scores
+from .ui.menu import show_race_outro
 
 AGENT_MAP = {
     "null": NullAgent,
@@ -138,6 +139,14 @@ def main() -> None:
             args.player,
             int(env.score),
         )
+        try:
+            show_race_outro(
+                getattr(env, "screen", None),
+                int(env.score),
+                duration=0 if FAST_TEST else 5.0,
+            )
+        except Exception:
+            pass
         env.close()
         print(metrics)
     else:
@@ -182,6 +191,14 @@ def main() -> None:
             args.player,
             int(env.score),
         )
+        try:
+            show_race_outro(
+                getattr(env, "screen", None),
+                int(env.score),
+                duration=0 if FAST_TEST else 5.0,
+            )
+        except Exception:
+            pass
         env.close()
         print(metrics)
 

--- a/super_pole_position/ui/menu.py
+++ b/super_pole_position/ui/menu.py
@@ -24,13 +24,56 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     pygame = None
 
-from ..evaluation.scores import load_scores
+from ..evaluation import scores as score_mod
+
+
+def show_race_outro(screen, score: int, duration: float = 5.0) -> None:
+    """Display final score and top high scores.
+
+    When pygame is unavailable this falls back to printing the scores
+    to ``stdout``. ``duration`` controls how long the overlay remains
+    visible in seconds.
+    """
+
+    scores = score_mod.load_scores(None)[:5]
+    if pygame is None:
+        print(f"FINAL SCORE {score}")
+        for i, s in enumerate(scores, 1):
+            print(f"{i}. {s['name']} {s['score']}")
+        return
+
+    if screen is None:
+        screen = pygame.display.set_mode((256, 224))
+
+    font = pygame.font.SysFont(None, 24)
+    clock = pygame.time.Clock()
+    frames = int(duration * 30)
+    count = 0
+    while count < frames:
+        for event in pygame.event.get():
+            if event.type in {pygame.KEYDOWN, pygame.QUIT}:
+                count = frames
+        screen.fill((0, 0, 0))
+        title = font.render("RACE OVER", True, (255, 255, 0))
+        screen.blit(title, (50, 20))
+        total = font.render(f"SCORE {score}", True, (255, 255, 255))
+        screen.blit(total, (50, 50))
+        header = font.render("TOP SCORES", True, (255, 255, 0))
+        screen.blit(header, (50, 80))
+        y = 110
+        for i, s in enumerate(scores, 1):
+            line = font.render(f"{i}. {s['name']} {s['score']}", True, (255, 255, 255))
+            screen.blit(line, (50, y))
+            y += 30
+        pygame.display.flip()
+        clock.tick(30)
+        count += 1
 
 
 def _show_high_scores(screen, font) -> None:
     """Display the top five scores until a key is pressed."""
 
-    scores = load_scores(None)[:5]
+    scores = score_mod.load_scores(None)[:5]
     clock = pygame.time.Clock()
     running = True
     while running:

--- a/tests/test_cli_outro.py
+++ b/tests/test_cli_outro.py
@@ -1,0 +1,34 @@
+import sys
+import pytest  # noqa: F401
+from super_pole_position import cli
+
+
+def test_cli_invokes_outro(monkeypatch):
+    calls = []
+
+    class DummyEnv:
+        def __init__(self, *_, **__):
+            self.score = 123
+            self.screen = None
+
+        def close(self):
+            pass
+
+    monkeypatch.setitem(sys.modules, "pygame", None)
+    monkeypatch.setattr(cli, "safe_run_episode", lambda env, agents: None)
+    monkeypatch.setattr(cli, "update_leaderboard", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "summary", lambda env: {})
+    monkeypatch.setattr(cli, "update_scores", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "PolePositionEnv", DummyEnv)
+
+    def fake_show(screen, score, duration=5.0):
+        calls.append(score)
+
+    monkeypatch.setattr(cli, "show_race_outro", fake_show)
+    monkeypatch.setattr(sys, "argv", ["spp", "race"])
+    monkeypatch.setenv("FAST_TEST", "1")
+
+    cli.main()
+
+    assert calls == [123]
+

--- a/tests/test_outro_fallback.py
+++ b/tests/test_outro_fallback.py
@@ -1,0 +1,12 @@
+import sys
+from super_pole_position.ui import menu
+
+
+def test_show_race_outro_fallback(capsys, monkeypatch):
+    monkeypatch.setattr(menu, "pygame", None)
+    monkeypatch.setattr(menu.score_mod, "load_scores", lambda *_: [{"name": "AAA", "score": 50}])
+    menu.show_race_outro(None, 42, duration=0)
+    out = capsys.readouterr().out
+    assert "FINAL SCORE 42" in out
+    assert "AAA" in out
+


### PR DESCRIPTION
## Summary
- show final high scores with score overlay when a race ends
- call outro from CLI after leaderboard updates
- ensure fallback text output when pygame unavailable
- handle FAST_TEST for non-blocking outro

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: gymnasium missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858d0f301708324aeb4d0b77e3456ee