### PR TITLE
Add chiptune fallback audio

### DIFF
--- a/assets/audio/generate_placeholders.py
+++ b/assets/audio/generate_placeholders.py
@@ -48,11 +48,40 @@ def checkpoint(duration: float = 0.2) -> np.ndarray:
     return tone * envelope
 
 
+def _square_wave(freq: float, duration: float) -> np.ndarray:
+    t = np.linspace(0, duration, int(SAMPLE_RATE * duration), endpoint=False)
+    return 0.5 * np.sign(np.sin(2 * math.pi * freq * t))
+
+
+def prepare_voice() -> np.ndarray:
+    notes = [(440, 0.15), (660, 0.15), (880, 0.3)]
+    return np.concatenate([_square_wave(f, d) for f, d in notes])
+
+
+def final_lap_voice() -> np.ndarray:
+    notes = [(660, 0.2), (660, 0.2), (880, 0.3)]
+    return np.concatenate([_square_wave(f, d) for f, d in notes])
+
+
+def goal_voice() -> np.ndarray:
+    notes = [(523, 0.2), (659, 0.25), (784, 0.35)]
+    return np.concatenate([_square_wave(f, d) for f, d in notes])
+
+
+def bgm_theme() -> np.ndarray:
+    melody = [(440, 0.2), (554, 0.2), (659, 0.4), (587, 0.2), (659, 0.2)]
+    return np.concatenate([_square_wave(f, d) for f, d in melody])
+
+
 GENERATORS: dict[str, Callable[[], np.ndarray]] = {
     "engine_loop.wav": engine_loop,
     "skid.wav": skid,
     "crash.wav": crash,
     "checkpoint.wav": checkpoint,
+    "prepare.wav": prepare_voice,
+    "final_lap.wav": final_lap_voice,
+    "goal.wav": goal_voice,
+    "bgm.wav": bgm_theme,
 }
 
 


### PR DESCRIPTION
## Summary
- synthesize missing audio at runtime with new chiptune functions
- load generated sounds when audio files are absent

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685908f682348324aad6a3185f70edfa