### PR TITLE
Add menu navigation audio

### DIFF
--- a/assets/audio/AUDIO.md
+++ b/assets/audio/AUDIO.md
@@ -8,6 +8,7 @@ simple chiptune-style samples if real audio is unavailable.
 - `skid.wav` – tire skid effect
 - `crash.wav` – crash explosion
 - `checkpoint.wav` – checkpoint chime
+- `menu_tick.wav` – short beep for menu navigation
 - `prepare.wav` – "Prepare to qualify" voice
 - `final_lap.wav` – "Final lap" call
 - `goal.wav` – finish line voice

--- a/assets/audio/generate_placeholders.py
+++ b/assets/audio/generate_placeholders.py
@@ -48,11 +48,21 @@ def checkpoint(duration: float = 0.2) -> np.ndarray:
     return tone * envelope
 
 
+def menu_tick(duration: float = 0.1) -> np.ndarray:
+    """Return short beep for menu navigation."""
+
+    t = np.linspace(0, duration, int(SAMPLE_RATE * duration), endpoint=False)
+    tone = np.sin(2 * math.pi * 660 * t)
+    envelope = np.exp(-12 * t)
+    return tone * envelope
+
+
 GENERATORS: dict[str, Callable[[], np.ndarray]] = {
     "engine_loop.wav": engine_loop,
     "skid.wav": skid,
     "crash.wav": crash,
     "checkpoint.wav": checkpoint,
+    "menu_tick.wav": menu_tick,
 }
 
 

--- a/src/audio/sfx.py
+++ b/src/audio/sfx.py
@@ -11,6 +11,7 @@ CHANNEL_MAP = {
     "skid": 1,
     "crash": 2,
     "checkpoint": 3,
+    "menu_tick": 4,
 }
 
 

--- a/super_pole_position/ui/menu.py
+++ b/super_pole_position/ui/menu.py
@@ -25,6 +25,7 @@ except Exception:  # pragma: no cover - optional dependency
     pygame = None
 
 from ..evaluation import scores as score_mod
+from ..audio.sfx import Sfx
 
 
 def show_race_outro(screen, score: int, duration: float = 5.0) -> None:
@@ -190,6 +191,13 @@ def main_loop(screen, seed: int | None = None) -> dict | None:
     backdrop = _load_backdrop(rng)
     state = MenuState()
     font = pygame.font.SysFont(None, 24)
+    audio_dir = Path(__file__).resolve().parent.parent / "assets" / "audio"
+    try:
+        if pygame.mixer and not pygame.mixer.get_init():
+            pygame.mixer.init()
+        tick_sfx = Sfx("menu_tick", audio_dir / "menu_tick.wav")
+    except Exception:  # pragma: no cover - audio failure
+        tick_sfx = None
     x_offset = 0
     running = True
     while running:
@@ -199,6 +207,8 @@ def main_loop(screen, seed: int | None = None) -> dict | None:
             if event.type == pygame.KEYDOWN:
                 name = pygame.key.name(event.key).upper()
                 result = state.handle(name)
+                if tick_sfx and name in {"UP", "DOWN", "LEFT", "RIGHT", "ENTER", "SPACE"}:
+                    tick_sfx.play()
                 if result is None or isinstance(result, dict):
                     return result
                 if name == "H":


### PR DESCRIPTION
## Summary
- add `menu_tick.wav` entry to audio assets
- generate simple beep placeholder for menu navigation
- assign mixer channel for new SFX
- play tick sound on menu keypresses

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q` *(fails: could not import 'gymnasium')*


------
https://chatgpt.com/codex/tasks/task_e_685908f682348324aad6a3185f70edfa