### PR TITLE
Add joystick agent for analog input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Added on-screen high-score display and `examples/reset_high_scores.py` utility.
 - Stereo engine audio now pans per player with `engine_pan_spread` and mixes
   alongside skid and crash effects.
+- Added `JoystickAgent` for analog wheel and gamepad control.
 
 📌 Keep racing for the next update! 🏁
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ Enable it with `--virtual-joystick` when launching a race or qualifying run:
 spp race --render --virtual-joystick
 ```
 
+### 🏁 Steering Wheels & Gamepads
+Use the new `joystick` agent for analog input from a wheel or gamepad. Simply
+connect your device and run:
+```bash
+spp race --render --agent joystick
+```
+
 🕹️ **CAR 2:** _(AI-Driven)_
 🤖 **Automated racing, planning, and learning**
 

--- a/super_pole_position/agents/__init__.py
+++ b/super_pole_position/agents/__init__.py
@@ -6,6 +6,7 @@
 """Agent implementations and controller helpers."""
 
 from .keyboard_agent import KeyboardAgent
+from .joystick_agent import JoystickAgent
 
-__all__ = ["KeyboardAgent"]
+__all__ = ["KeyboardAgent", "JoystickAgent"]
 

--- a/super_pole_position/agents/joystick_agent.py
+++ b/super_pole_position/agents/joystick_agent.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Joystick controls with analog steering and throttle. 🕹️"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+# Hide pygame's greeting for cleaner logs
+os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
+
+try:
+    import pygame  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    pygame = None
+
+from .base_llm_agent import BaseLLMAgent
+
+
+@dataclass
+class JoystickConfig:
+    """Configuration for axis/button mapping."""
+
+    steer_axis: int = 0
+    throttle_axis: int = 1
+    brake_axis: int | None = None
+    shift_up_button: int | None = None
+    shift_down_button: int | None = None
+    dead_zone: float = 0.05
+
+
+class JoystickAgent(BaseLLMAgent):
+    """Human agent using a physical joystick or wheel."""
+
+    def __init__(self, config: JoystickConfig | None = None) -> None:
+        self.config = config or JoystickConfig()
+        self.joystick = None
+        if pygame is not None:
+            try:  # pragma: no cover - optional dependency
+                pygame.joystick.init()
+                if pygame.joystick.get_count() > 0:
+                    self.joystick = pygame.joystick.Joystick(0)
+                    self.joystick.init()
+            except Exception:
+                self.joystick = None
+
+    def _axis(self, idx: int) -> float:
+        if self.joystick is None:
+            return 0.0
+        val = float(self.joystick.get_axis(idx))
+        if abs(val) < self.config.dead_zone:
+            return 0.0
+        return val
+
+    def act(self, observation) -> dict:
+        """Return action based on joystick input."""
+        if pygame is None or self.joystick is None:
+            return {"throttle": 0, "brake": 0, "steer": 0.0, "gear": 0}
+
+        pygame.event.pump()
+
+        steer = self._axis(self.config.steer_axis)
+        throttle_val = -self._axis(self.config.throttle_axis)
+        throttle = max(0.0, min(1.0, (throttle_val + 1) / 2))
+
+        brake = 0.0
+        if self.config.brake_axis is not None:
+            brake_val = self._axis(self.config.brake_axis)
+            brake = max(0.0, min(1.0, (brake_val + 1) / 2))
+
+        gear = 0
+        if self.config.shift_up_button is not None and self.joystick.get_numbuttons() > self.config.shift_up_button:
+            if self.joystick.get_button(self.config.shift_up_button):
+                gear = 1
+        if self.config.shift_down_button is not None and self.joystick.get_numbuttons() > self.config.shift_down_button:
+            if self.joystick.get_button(self.config.shift_down_button):
+                gear = -1
+
+        return {
+            "throttle": throttle,
+            "brake": brake,
+            "steer": steer,
+            "gear": gear,
+        }

--- a/super_pole_position/cli.py
+++ b/super_pole_position/cli.py
@@ -19,6 +19,7 @@ from .agents.base_llm_agent import NullAgent
 from .agents.openai_agent import OpenAIAgent
 from .agents.mistral_agent import MistralAgent
 from .agents.keyboard_agent import KeyboardAgent
+from .agents.joystick_agent import JoystickAgent
 
 from .envs.pole_position import PolePositionEnv, FAST_TEST
 from .matchmaking.arena import run_episode, update_leaderboard
@@ -32,6 +33,7 @@ AGENT_MAP = {
     "openai": OpenAIAgent,
     "mistral": MistralAgent,
     "keyboard": KeyboardAgent,
+    "joystick": JoystickAgent,
 }
 
 


### PR DESCRIPTION
## Summary
- provide `JoystickAgent` for steering wheels & gamepads
- expose the agent via the CLI
- mention analog controls in the README
- document joystick support in the changelog

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q` *(fails: could not import 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_685913011fb883249aecd453a0f1252e