### PR TITLE
Implement banked sprites and green terrain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Stereo engine audio now pans per player with `engine_pan_spread` and mixes
   alongside skid and crash effects.
 - Added `JoystickAgent` for analog wheel and gamepad control.
+- Off-track ground now renders in green with leaning car sprites.
 
 📌 Keep racing for the next update! 🏁
 

--- a/PROGRESS_ARCADE_PARITY.md
+++ b/PROGRESS_ARCADE_PARITY.md
@@ -22,5 +22,6 @@
 - [x] Lap times posted to scoreboard API
 - [x] Lap time leaderboard accessible via API
 - [x] Player name recorded in high-score table
+- [x] Grass-colored terrain and banked car sprites
 
 🎉 All core arcade mechanics implemented! 🏁

--- a/src/render/pseudo3d_renderer.py
+++ b/src/render/pseudo3d_renderer.py
@@ -29,6 +29,7 @@ BASE_ROAD_HALF = 77.0
 ROAD_GRAY = (60, 60, 60)
 HORIZON_GAIN = 120
 STRIPE_COLOR = (250, 250, 250)
+BANK_THRESHOLD = 0.4
 
 
 class Renderer:
@@ -191,7 +192,7 @@ class Renderer:
         for name, depth, lateral in sprites_sorted:
             frame = name
             steer = getattr(env, "last_steer", 0.0)
-            if name == "player_car" and abs(steer) > 0.5:
+            if name == "player_car" and abs(steer) > BANK_THRESHOLD:
                 frame = "player_car_bankR" if steer > 0 else "player_car_bankL"
             img = self.sprites.get(frame)
             if not img:

--- a/super_pole_position/ui/arcade.py
+++ b/super_pole_position/ui/arcade.py
@@ -297,11 +297,13 @@ class Pseudo3DRenderer:
         self.sky_top = Palette.sky_blue
         self.sky_bottom = (80, 160, 208)
         self.sky_color = Palette.sky_blue
-        self.ground_color = Palette.grey
+        self.ground_color = Palette.green
         self.car_color = Palette.red
         self.player_car_sprite = _load_sprite("player_car.png") or ascii_surface(
             CAR_ART
         )
+        self.player_car_left = _load_sprite("player_car_bankL.png")
+        self.player_car_right = _load_sprite("player_car_bankR.png")
         self.cpu_front_sprite = _load_sprite("cpu_car.png") or ascii_surface(CAR_ART)
         self.billboard_sprites = []
         for i in range(1, 9):
@@ -544,6 +546,12 @@ class Pseudo3DRenderer:
         sprite = self.player_car_sprite
         if dist < env.track.width / 2:
             sprite = self.cpu_front_sprite
+        elif abs(getattr(env, "last_steer", 0.0)) > 0.5:
+            sprite = (
+                self.player_car_right
+                if getattr(env, "last_steer", 0.0) > 0
+                else self.player_car_left
+            ) or sprite
         if sprite:
             img = pygame.transform.scale(sprite, rect.size)
             surface.blit(img, rect)


### PR DESCRIPTION
## Summary
- color off-track ground as grass
- load banked car sprites and use them on sharp turns
- tune pseudo-3D bank switching with a constant
- document new milestone in PROGRESS_ARCADE_PARITY
- note update in CHANGELOG

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68598a64b6408324b2b608bfdd84b569