### PR TITLE
Add green grass and sprite leaning

### DIFF
--- a/super_pole_position/ui/arcade.py
+++ b/super_pole_position/ui/arcade.py
@@ -297,7 +297,7 @@ class Pseudo3DRenderer:
         self.sky_top = Palette.sky_blue
         self.sky_bottom = (80, 160, 208)
         self.sky_color = Palette.sky_blue
-        self.ground_color = Palette.grey
+        self.ground_color = Palette.green
         self.car_color = Palette.red
         self.player_car_sprite = _load_sprite("player_car.png") or ascii_surface(
             CAR_ART
@@ -546,6 +546,11 @@ class Pseudo3DRenderer:
             sprite = self.cpu_front_sprite
         if sprite:
             img = pygame.transform.scale(sprite, rect.size)
+            steer = getattr(env, "last_steer", 0.0)
+            if abs(steer) > 0.5:
+                angle = -15 if steer > 0 else 15
+                img = pygame.transform.rotate(img, angle)
+                rect = img.get_rect(center=rect.center)
             surface.blit(img, rect)
         else:
             pygame.draw.rect(surface, self.car_color, rect)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -20,3 +20,11 @@ def test_draw_road_polygon_offset():
     assert poly[2][0] == pytest.approx(width / 2 + expected + road_top / 2)
     assert poly[3][0] == pytest.approx(width / 2 + expected - road_top / 2)
     pygame.display.quit()
+
+
+def test_ground_color_green() -> None:
+    pygame.display.init()
+    screen = pygame.display.set_mode((320, 240))
+    renderer = Pseudo3DRenderer(screen)
+    assert renderer.ground_color == (0, 184, 0)
+    pygame.display.quit()


### PR DESCRIPTION
## Summary
- use green ground color
- rotate player sprite when steering hard
- assert green grass in renderer tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68598a64b6408324b2b608bfdd84b569