### PR TITLE
Improve synthesized audio cues

### DIFF
--- a/assets/audio/generate_placeholders.py
+++ b/assets/audio/generate_placeholders.py
@@ -21,9 +21,13 @@ def write_wav(path: Path, data: np.ndarray) -> None:
 
 
 def engine_loop(duration: float = 1.0) -> np.ndarray:
+    """Return looping engine drone with slight vibrato."""
+
     t = np.linspace(0, duration, int(SAMPLE_RATE * duration), endpoint=False)
-    base = 0.4 * np.sin(2 * math.pi * 220 * t)
-    harm = 0.2 * np.sin(2 * math.pi * 440 * t)
+    wobble = 0.02 * np.sin(2 * math.pi * 8 * t)
+    freq = 220 * (1.0 + wobble)
+    base = 0.4 * np.sin(2 * math.pi * freq * t)
+    harm = 0.2 * np.sin(2 * math.pi * freq * 2 * t)
     return base + harm
 
 
@@ -68,6 +72,20 @@ def prepare_voice() -> np.ndarray:
     return np.concatenate([_square_wave(f, d) for f, d in notes])
 
 
+def prepare_qualify_voice() -> np.ndarray:
+    """Voice cue for 'Prepare to Qualify'."""
+
+    notes = [(440, 0.15), (660, 0.15), (880, 0.3)]
+    return np.concatenate([_square_wave(f, d) for f, d in notes])
+
+
+def prepare_race_voice() -> np.ndarray:
+    """Voice cue for 'Prepare to Race'."""
+
+    notes = [(392, 0.15), (523, 0.15), (784, 0.3)]
+    return np.concatenate([_square_wave(f, d) for f, d in notes])
+
+
 def final_lap_voice() -> np.ndarray:
     notes = [(660, 0.2), (660, 0.2), (880, 0.3)]
     return np.concatenate([_square_wave(f, d) for f, d in notes])
@@ -96,6 +114,8 @@ GENERATORS: dict[str, Callable[[], np.ndarray]] = {
     "checkpoint.wav": checkpoint,
     "menu_tick.wav": menu_tick,
     "prepare.wav": prepare_voice,
+    "prepare_qualify.wav": prepare_qualify_voice,
+    "prepare_race.wav": prepare_race_voice,
     "final_lap.wav": final_lap_voice,
     "goal.wav": goal_voice,
     "shift.wav": shift_click,

--- a/config.arcade_parity.yaml
+++ b/config.arcade_parity.yaml
@@ -9,6 +9,9 @@ scanline_step: 2
 scanline_spacing: 2
 scanline_alpha: 60
 audio_volume: 0.8
+engine_volume: 0.8
+voice_volume: 1.0
+effects_volume: 0.8
 engine_pan_spread: 0.8
 horizon_sway: 0.12
 

--- a/super_pole_position/config.py
+++ b/super_pole_position/config.py
@@ -13,6 +13,9 @@ except Exception:  # pragma: no cover - PyYAML optional
 DEFAULTS = {
     "puddle": {"speed_factor": 0.65, "angle_jitter": 0.2},
     "audio_volume": 0.8,
+    "engine_volume": 0.8,
+    "voice_volume": 1.0,
+    "effects_volume": 0.8,
     "engine_pan_spread": 0.8,
 }
 
@@ -38,6 +41,12 @@ def load_parity_config() -> dict[str, Any]:
             cfg["audio_volume"] = float(data["audio_volume"])
         except (TypeError, ValueError):
             cfg["audio_volume"] = DEFAULTS["audio_volume"]
+    for key in ("engine_volume", "voice_volume", "effects_volume"):
+        if key in data:
+            try:
+                cfg[key] = float(data[key])
+            except (TypeError, ValueError):
+                cfg[key] = DEFAULTS[key]
     if "engine_pan_spread" in data:
         try:
             cfg["engine_pan_spread"] = float(data["engine_pan_spread"])


### PR DESCRIPTION
## Summary
- generate 'prepare_qualify' and 'prepare_race' voices
- load extra voice samples and per-category volumes
- add vibrato to engine audio generation
- expose new audio volume knobs in config
- play background music once instead of loop

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install gymnasium==0.29.1`
- `pip install pygame==2.5.2`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859ac68d08483248736e7dc5ea6f8a2