### PR TITLE
Update parity docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
   `config.arcade_parity.yaml` with optional brake disable using
   `DISABLE_BRAKE`.
 - Off-track ground now renders in green with leaning car sprites.
+- Documented upcoming arcade-parity tasks in `PROGRESS_ARCADE_PARITY.md` and
+  added roadmap items for qualify-to-race and high-score table.
 
 📌 Keep racing for the next update! 🏁
 

--- a/PROGRESS_ARCADE_PARITY.md
+++ b/PROGRESS_ARCADE_PARITY.md
@@ -25,3 +25,14 @@
 - [x] Grass-colored terrain and banked car sprites
 
 🎉 All core arcade mechanics implemented! 🏁
+
+## Upcoming Features
+
+- [ ] Qualify-to-race transition with start position message
+- [ ] Score bonus tiers for high qualifying ranks
+- [ ] Difficulty options for time allowance per lap
+- [ ] Expanded end-of-race sequence with rank display
+- [ ] Local high-score entry and leaderboard screen
+- [ ] Optional attract mode cycling the leaderboard
+- [ ] Finish-line check when timer hits exactly zero
+- [ ] Puddles placed at original track corners

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,6 +12,10 @@ This document highlights planned milestones for upcoming releases.
 - Enhanced telemetry output via WebSockets.
 - Visualization notebooks for replay analysis.
 - Integrated AI replay viewer.
+- Qualify-to-race transition and grid ranking.
+- End-of-race rank screen and local high scores.
+- Difficulty presets for time allowance tweaks.
+- Optional attract mode cycling leaderboard.
 
 ## 🏆 v2.0.0
 - Community model submissions and tournament mode.


### PR DESCRIPTION
## Summary
- outline upcoming arcade-parity goals
- expand roadmap with parity milestones
- note parity docs in changelog

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q` *(fails: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_6859c15c2bf883248e4676e61a54b9f5