### PR TITLE
Update HUD toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ spp scoreboard-sync --host 127.0.0.1 --port 8000 --interval 30
 - Try `--hyper` for a *next-gen AI challenge*
 - Display performance metrics by setting `PERF_HUD=1`
 - Mute background music via `--mute-bgm`
+- Hide gear or mini-map with `HUD_GEAR=0` or `HUD_MINIMAP=0`
 
 ## 🎞️ Animated Sprite Demo
 A small example using **Pygame 2** can be found in `examples/animated_sprite.py`.

--- a/config.arcade_parity.yaml
+++ b/config.arcade_parity.yaml
@@ -17,3 +17,5 @@ horizon_sway: 0.12
 
 
 turn_rate: 2.5
+show_gear: 1
+show_minimap: 1

--- a/tests/test_hud_toggles.py
+++ b/tests/test_hud_toggles.py
@@ -1,0 +1,51 @@
+import os
+import types
+import pytest
+pygame = pytest.importorskip("pygame")  # noqa: E402
+from super_pole_position.ui.arcade import Pseudo3DRenderer  # noqa: E402
+
+
+def test_hud_gear_toggle(monkeypatch):
+    pygame.display.init()
+    pygame.font.init()
+    screen = pygame.display.set_mode((160, 120))
+    monkeypatch.setenv("HUD_GEAR", "0")
+    renderer = Pseudo3DRenderer(screen)
+    assert not renderer.show_gear
+    env = types.SimpleNamespace(
+        mode="race",
+        cars=[types.SimpleNamespace(speed=0, gear=0, x=0, y=0)],
+        traffic=[],
+        track=types.SimpleNamespace(width=100, height=100, start_x=0,
+                                    distance=lambda a,b: 10,
+                                    angle_at=lambda x: 0),
+        remaining_time=0.0,
+        lap_timer=None,
+        lap_flash=0.0,
+        last_lap_time=None,
+        lap=0,
+        start_phase="",
+        message_timer=0,
+        game_message="",
+        current_step=0,
+        time_extend_flash=0,
+    )
+    texts = []
+    class DummyFont:
+        def render(self, text, aa, color):
+            texts.append(text)
+            return pygame.Surface((1, 1))
+    monkeypatch.setattr(pygame.font, "SysFont", lambda *a, **k: DummyFont())
+    renderer.draw(env)
+    assert all("GEAR" not in t for t in texts)
+    pygame.display.quit()
+
+
+def test_hud_minimap_toggle(monkeypatch):
+    pygame.display.init()
+    pygame.font.init()
+    screen = pygame.display.set_mode((160, 120))
+    monkeypatch.setenv("HUD_MINIMAP", "0")
+    renderer = Pseudo3DRenderer(screen)
+    assert not renderer.show_minimap
+    pygame.display.quit()


### PR DESCRIPTION
## Summary
- add `show_gear` and `show_minimap` options
- allow disabling gear and minimap HUD via env vars
- display position as rank only and move to screen right
- document HUD toggles in README
- test HUD toggle behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: Skipped: could not import 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_6859eb3653388324bc4138a2575eeca9