### PR TITLE
Update HUD toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ spp scoreboard-sync --host 127.0.0.1 --port 8000 --interval 30
 - Try `--hyper` for a *next-gen AI challenge*
 - Display performance metrics by setting `PERF_HUD=1`
 - Mute background music via `--mute-bgm`
+- Hide gear or mini-map with `HUD_GEAR=0` or `HUD_MINIMAP=0`
 
 ## 🎞️ Animated Sprite Demo
 A small example using **Pygame 2** can be found in `examples/animated_sprite.py`.

--- a/config.arcade_parity.yaml
+++ b/config.arcade_parity.yaml
@@ -17,3 +17,5 @@ horizon_sway: 0.12
 
 
 turn_rate: 2.5
+show_gear: 1
+show_minimap: 1

--- a/super_pole_position/ui/arcade.py
+++ b/super_pole_position/ui/arcade.py
@@ -97,9 +97,15 @@ def _load_sprite(name: str) -> "pygame.Surface | None":
 
 
 def _load_arcade_config() -> Dict[str, float]:
-    """Return scanline configuration from ``config.arcade_parity.yaml``."""
+    """Return HUD and display settings from ``config.arcade_parity.yaml``."""
 
-    cfg: Dict[str, float] = {"scanline_step": 2, "scanline_alpha": 255, "horizon_sway": 0.1}
+    cfg: Dict[str, float] = {
+        "scanline_step": 2,
+        "scanline_alpha": 255,
+        "horizon_sway": 0.1,
+        "show_gear": 1,
+        "show_minimap": 1,
+    }
     path = Path(__file__).resolve().parents[2] / "config.arcade_parity.yaml"
     try:
         with open(path, "r", encoding="utf-8") as fh:
@@ -331,6 +337,10 @@ class Pseudo3DRenderer:
         self.scanline_step = cfg["scanline_step"]
         self.scanline_alpha = cfg["scanline_alpha"]
         self.horizon_sway = float(cfg.get("horizon_sway", HORIZON_SWAY))
+        self.show_gear = os.environ.get("HUD_GEAR", str(int(cfg.get("show_gear", 1)))) != "0"
+        self.show_minimap = os.environ.get(
+            "HUD_MINIMAP", str(int(cfg.get("show_minimap", 1)))
+        ) != "0"
         if pygame:
             self._scanline_row = pygame.Surface((1, 1), pygame.SRCALPHA)
             self._scanline_row.fill((0, 0, 0, self.scanline_alpha))
@@ -536,7 +546,7 @@ class Pseudo3DRenderer:
 
         # Render opponent cars sorted by distance (farthest first)
         if env.mode == "race":
-            opponents = [env.cars[1]] + list(env.traffic)
+            opponents = list(env.cars[1:]) + list(env.traffic)
         else:
             opponents = []
 
@@ -605,17 +615,19 @@ class Pseudo3DRenderer:
                     ahead = (car.x - player.x) % env.track.width
                     if ahead > 0:
                         rank += 1
-            total = len(env.traffic) + 1
-            pos_text = font.render(f"POS {rank}/{total}", True, (0, 255, 0))
-            surface.blit(lap_text, (10, 50))
-            surface.blit(pos_text, (10, 70))
+            pos_text = font.render(f"RANK {rank}", True, (0, 255, 0))
+            lx = width - lap_text.get_width() - 10
+            px = width - pos_text.get_width() - 10
+            surface.blit(lap_text, (lx, 50))
+            surface.blit(pos_text, (px, 70))
 
             mph = int(player.speed * 2.23694)
             spd_text = font.render(f"SPEED {mph} MPH", True, (255, 255, 255))
             gear = "H" if player.gear else "L"
-            gear_text = font.render(f"GEAR {gear}", True, (255, 255, 255))
             surface.blit(spd_text, (width - spd_text.get_width() - 10, 10))
-            surface.blit(gear_text, (width - gear_text.get_width() - 10, 30))
+            if self.show_gear:
+                gear_text = font.render(f"GEAR {gear}", True, (255, 255, 255))
+                surface.blit(gear_text, (width - gear_text.get_width() - 10, 30))
 
             perf_lines = []
             if os.environ.get("PERF_HUD", "0") != "0":
@@ -629,7 +641,7 @@ class Pseudo3DRenderer:
             t = font.render(line, True, (255, 255, 255))
             surface.blit(t, (width - 160, 30 + 20 * i))
 
-            # mini-map simple dot positions
+        if self.show_minimap:
             map_h = 80
             map_w = 80
             pygame.draw.rect(
@@ -640,10 +652,17 @@ class Pseudo3DRenderer:
             )
             px = width - map_w - 10 + (player.x / env.track.width) * map_w
             py = 10 + (player.y / env.track.height) * map_h
-            ox = width - map_w - 10 + (other.x / env.track.width) * map_w
-            oy = 10 + (other.y / env.track.height) * map_h
             pygame.draw.circle(surface, (255, 0, 0), (int(px), int(py)), 3)
-            pygame.draw.circle(surface, (0, 255, 0), (int(ox), int(oy)), 3)
+
+            opponents = []
+            if len(getattr(env, "cars", [])) > 1:
+                opponents.append(env.cars[1])
+            opponents.extend(getattr(env, "traffic", []))
+
+            for opp in opponents:
+                ox = width - map_w - 10 + (opp.x / env.track.width) * map_w
+                oy = 10 + (opp.y / env.track.height) * map_h
+                pygame.draw.circle(surface, (0, 255, 0), (int(ox), int(oy)), 3)
 
         # Starting lights / ready-set-go text
         if self.start_font and env.current_step < 30:

--- a/tests/test_hud_toggles.py
+++ b/tests/test_hud_toggles.py
@@ -1,0 +1,51 @@
+import os
+import types
+import pytest
+pygame = pytest.importorskip("pygame")  # noqa: E402
+from super_pole_position.ui.arcade import Pseudo3DRenderer  # noqa: E402
+
+
+def test_hud_gear_toggle(monkeypatch):
+    pygame.display.init()
+    pygame.font.init()
+    screen = pygame.display.set_mode((160, 120))
+    monkeypatch.setenv("HUD_GEAR", "0")
+    renderer = Pseudo3DRenderer(screen)
+    assert not renderer.show_gear
+    env = types.SimpleNamespace(
+        mode="race",
+        cars=[types.SimpleNamespace(speed=0, gear=0, x=0, y=0)],
+        traffic=[],
+        track=types.SimpleNamespace(width=100, height=100, start_x=0,
+                                    distance=lambda a,b: 10,
+                                    angle_at=lambda x: 0),
+        remaining_time=0.0,
+        lap_timer=None,
+        lap_flash=0.0,
+        last_lap_time=None,
+        lap=0,
+        start_phase="",
+        message_timer=0,
+        game_message="",
+        current_step=0,
+        time_extend_flash=0,
+    )
+    texts = []
+    class DummyFont:
+        def render(self, text, aa, color):
+            texts.append(text)
+            return pygame.Surface((1, 1))
+    monkeypatch.setattr(pygame.font, "SysFont", lambda *a, **k: DummyFont())
+    renderer.draw(env)
+    assert all("GEAR" not in t for t in texts)
+    pygame.display.quit()
+
+
+def test_hud_minimap_toggle(monkeypatch):
+    pygame.display.init()
+    pygame.font.init()
+    screen = pygame.display.set_mode((160, 120))
+    monkeypatch.setenv("HUD_MINIMAP", "0")
+    renderer = Pseudo3DRenderer(screen)
+    assert not renderer.show_minimap
+    pygame.display.quit()


### PR DESCRIPTION
## Summary
- add `show_gear` and `show_minimap` options
- allow disabling gear and minimap HUD via env vars
- display position as rank only and move to screen right
- document HUD toggles in README
- test HUD toggle behaviour
- fix minimap opponent dots
- guard opponents list

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails to import gymnasium)*

------
https://chatgpt.com/codex/tasks/task_e_6859eb3653388324bc4138a2575eeca9