### PR TITLE
Fix gear shift double-counting

### DIFF
--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -451,11 +451,9 @@ class PolePositionEnv(gym.Env):
         shifted = self.cars[0].shift(gear_cmd)
         if shifted:
             self._play_shift_audio()
-        if gear_cmd:
             self._play_shift_sound()
             self.game_message = "HIGH" if gear_cmd > 0 else "LOW"
             self.message_timer = 1.0
-        self.cars[0].shift(gear_cmd)
         self.cars[0].apply_controls(throttle, brake, steer, dt=dt, track=self.track)
         self.last_steer = steer
 

--- a/tests/test_gear_shift.py
+++ b/tests/test_gear_shift.py
@@ -15,6 +15,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from super_pole_position.physics.car import Car
+from super_pole_position.envs.pole_position import PolePositionEnv
 
 
 def test_shift_changes_max_speed():
@@ -26,3 +27,14 @@ def test_shift_changes_max_speed():
     for _ in range(10):
         car.apply_controls(True, False, 0.0, dt=1.0)
     assert car.speed <= car.gear_max[1]
+
+
+def test_env_shift_increments_once():
+    env = PolePositionEnv(render_mode="human")
+    env.reset()
+    env.start_timer = 0
+    before = env.cars[0].shift_count
+    env.step((False, False, 0.0, 1))
+    after = env.cars[0].shift_count
+    assert after - before == 1
+    env.close()


### PR DESCRIPTION
## Summary
- avoid calling `shift` twice in PolePositionEnv
- test that gear shifting increments once

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4e7ed43483249e5405fac4ef1b33