### PR TITLE
Add custom env parameter example

### DIFF
--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -28,3 +28,21 @@ def test_reset_and_step():
     assert isinstance(reward, float)
     assert len(obs) == 17
     env.close()
+
+
+def test_custom_parameters() -> None:
+    """Initialize ``PolePositionEnv`` with non-default settings."""
+    env = PolePositionEnv(
+        render_mode="human",
+        mode="qualify",
+        track_name="fuji",
+        hyper=True,
+        player_name="ACE",
+        slipstream=False,
+    )
+    env.reset()
+    assert env.mode == "qualify"
+    assert env.player_name == "ACE"
+    assert env.slipstream_enabled is False
+    assert env.hyper is True
+    env.close()


### PR DESCRIPTION
## Summary
- add minimal example for configuring `PolePositionEnv`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aa5c241bc832480d9e0b8d79c9c52