### PR TITLE
Add checkpoint sound effect

### DIFF
--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -206,7 +206,7 @@ class PolePositionEnv(gym.Env):
 
         self.audio_stream = None
         self.engine_channel = None
-        base = Path(__file__).resolve().parent.parent / "assets" / "audio"
+        base = Path(__file__).resolve().parent.parent.parent / "assets" / "audio"
         gen_path = base / "generate_placeholders.py"
         gen_mod = None
         if gen_path.exists():
@@ -257,6 +257,9 @@ class PolePositionEnv(gym.Env):
         self.prepare_race_wave = _load_audio("prepare_race.wav", "prepare_race_voice", self.voice_volume)
         self.final_lap_wave = _load_audio("final_lap.wav", "final_lap_voice", self.voice_volume)
         self.goal_wave = _load_audio("goal.wav", "goal_voice", self.voice_volume)
+        self.checkpoint_wave = _load_audio(
+            "checkpoint.wav", "checkpoint", self.effects_volume
+        )
         self.shift_wave = _load_audio("menu_tick.wav", "menu_tick", self.effects_volume)
         self.shift_wave = _load_audio("shift.wav", "shift_click", self.effects_volume)
         self.bgm_wave = _load_audio("bgm.wav", "bgm_theme", self.effects_volume)
@@ -633,6 +636,7 @@ class PolePositionEnv(gym.Env):
             self.lap_flash = 2.0
             self.remaining_time += 30.0
             self.time_extend_flash = 2.0
+            self._play_checkpoint_audio()
             print(f"[ENV] Completed lap {self.lap} in {self.last_lap_time:.2f}s", flush=True)
             try:
                 submit_lap_time_http(
@@ -993,6 +997,18 @@ class PolePositionEnv(gym.Env):
                 return
         sound = pygame.sndarray.make_sound(waveform_int16)
         self.audio_stream = sound.play()
+
+    def _play_checkpoint_audio(self) -> None:
+        """Play checkpoint chime when time extends."""
+
+        if pg_mixer is None:
+            return
+        if self.checkpoint_wave is None:
+            return
+        try:
+            self.checkpoint_wave.play()
+        except Exception:  # pragma: no cover
+            pass
 
     def _play_shift_audio(self) -> None:
         """Play a short click when shifting gears."""

--- a/tests/test_audio_triggers.py
+++ b/tests/test_audio_triggers.py
@@ -25,3 +25,9 @@ def test_step_with_audio_no_exception():
     env.cars[0].speed = 6.0
     env.step((True, False, 1.0))
     env.close()
+
+
+def test_checkpoint_sound_loaded():
+    env = PolePositionEnv(render_mode="human")
+    assert env.checkpoint_wave is not None
+    env.close()


### PR DESCRIPTION
## Summary
- load `checkpoint.wav` placeholder
- play checkpoint sound when lap finishes
- ensure audio assets path resolves correctly
- test for checkpoint sound loaded

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aa5c241bc832480d9e0b8d79c9c52