### PR TITLE
Add qualifying bonuses and timer grace

### DIFF
--- a/PROGRESS_ARCADE_PARITY.md
+++ b/PROGRESS_ARCADE_PARITY.md
@@ -29,10 +29,10 @@
 ## Upcoming Features
 
 - [ ] Qualify-to-race transition with start position message
-- [ ] Score bonus tiers for high qualifying ranks
+- [x] Score bonus tiers for high qualifying ranks
 - [ ] Difficulty options for time allowance per lap
 - [ ] Expanded end-of-race sequence with rank display
 - [ ] Local high-score entry and leaderboard screen
 - [ ] Optional attract mode cycling the leaderboard
-- [ ] Finish-line check when timer hits exactly zero
+- [x] Finish-line check when timer hits exactly zero
 - [ ] Puddles placed at original track corners


### PR DESCRIPTION
## Summary
- implement ordinal helpers and qualifying bonus logic
- allow lap completion when timer hits zero
- track player rank and display message
- mark parity progress for finished features

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_685ab09d566883248212d5b7b07c41fb