### PR TITLE
Fix TrackCurve segment start bug

### DIFF
--- a/super_pole_position/physics/track_curve.py
+++ b/super_pole_position/physics/track_curve.py
@@ -36,8 +36,8 @@ class TrackCurve:
         """Precompute polyline points spaced one meter apart."""
         x, y, angle = 0.0, 0.0, 0.0
         self._points.append((x, y))
-        for seg in self.segments:
-            if seg != self.segments[0]:
+        for i, seg in enumerate(self.segments):
+            if i > 0:
                 x, y = seg.x, seg.y
             dist = 0.0
             while dist < seg.length:


### PR DESCRIPTION
## Summary
- handle identical segments correctly when building TrackCurve

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_685acf072f4483249b00a62dbda4ab3b