### PR TITLE
Implement difficulty presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   `config.arcade_parity.yaml` with optional brake disable using
   `DISABLE_BRAKE`.
 - Off-track ground now renders in green with leaning car sprites.
+- Difficulty setting added with expert mode shortening time limits.
 - Documented upcoming arcade-parity tasks in `PROGRESS_ARCADE_PARITY.md` and
   added roadmap items for qualify-to-race and high-score table.
 

--- a/PROGRESS_ARCADE_PARITY.md
+++ b/PROGRESS_ARCADE_PARITY.md
@@ -30,7 +30,7 @@
 
 - [ ] Qualify-to-race transition with start position message
 - [x] Score bonus tiers for high qualifying ranks
-- [ ] Difficulty options for time allowance per lap
+- [x] Difficulty options for time allowance per lap
 - [ ] Expanded end-of-race sequence with rank display
 - [ ] Local high-score entry and leaderboard screen
 - [ ] Optional attract mode cycling the leaderboard

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ python examples/animated_sprite.py
 - Esc – Quit the demo
 - Use `--virtual-joystick` for touchscreen controls
 - Use `--no-brake` for brake-free purist mode
+- Select harder races with `--difficulty expert`
 
 🚗 Happy racing! 🏁
 

--- a/super_pole_position/cli.py
+++ b/super_pole_position/cli.py
@@ -58,6 +58,12 @@ def main() -> None:
         action="store_true",
         help="Disable brake input for purist mode",
     )
+    q.add_argument(
+        "--difficulty",
+        choices=["beginner", "expert"],
+        default="beginner",
+        help="Set difficulty level for time limits",
+    )
 
     r = sub.add_parser("race")
     r.add_argument("--agent", choices=list(AGENT_MAP.keys()), default="null")
@@ -74,6 +80,12 @@ def main() -> None:
         "--no-brake",
         action="store_true",
         help="Disable brake input for purist mode",
+    )
+    r.add_argument(
+        "--difficulty",
+        choices=["beginner", "expert"],
+        default="beginner",
+        help="Set difficulty level for time limits",
     )
 
     sub.add_parser("hiscore")
@@ -134,12 +146,14 @@ def main() -> None:
             if cfg is None:
                 return
             args.track = cfg.get("track", args.track)
+            args.difficulty = cfg.get("difficulty", args.difficulty)
             os.environ["AUDIO"] = "1" if cfg.get("audio", True) else "0"
         env = PolePositionEnv(
             render_mode="human",
             mode="qualify",
             track_name=args.track,
             player_name=args.player,
+            difficulty=args.difficulty,
         )
         agent_cls = AGENT_MAP.get(args.agent, NullAgent)
         agent = agent_cls()
@@ -186,12 +200,14 @@ def main() -> None:
             if cfg is None:
                 return
             args.track = cfg.get("track", args.track)
+            args.difficulty = cfg.get("difficulty", args.difficulty)
             os.environ["AUDIO"] = "1" if cfg.get("audio", True) else "0"
         env = PolePositionEnv(
             render_mode="human",
             mode="race",
             track_name=args.track,
             player_name=args.player,
+            difficulty=args.difficulty,
         )
         agent_cls = AGENT_MAP.get(args.agent, NullAgent)
         agent = agent_cls()

--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -90,6 +90,7 @@ class PolePositionEnv(gym.Env):
         hyper: bool = False,
         player_name: str = "PLAYER",
         slipstream: bool = True,
+        difficulty: str = "beginner",
     ) -> None:
         """Create a Pole Position environment.
 
@@ -106,8 +107,13 @@ class PolePositionEnv(gym.Env):
         self.hyper = hyper
         self.player_name = player_name
         self.slipstream_enabled = slipstream
+        self.difficulty = difficulty
 
-        self.time_limit = 90.0 if self.mode == "race" else 73.0
+        limits = {
+            "beginner": {"race": 90.0, "qualify": 73.0},
+            "expert": {"race": 75.0, "qualify": 60.0},
+        }
+        self.time_limit = limits.get(difficulty, limits["beginner"])[self.mode]
         self.traffic_count = 7 if self.mode == "race" else 0
         if FAST_TEST:
             self.time_limit = min(self.time_limit, 20.0)

--- a/tests/test_cli_difficulty.py
+++ b/tests/test_cli_difficulty.py
@@ -1,0 +1,26 @@
+import sys
+import pytest  # noqa: F401
+from super_pole_position import cli
+
+
+def test_cli_difficulty_option(monkeypatch):
+    recorded = {}
+
+    class DummyEnv:
+        def __init__(self, *_, difficulty="beginner", **__):
+            recorded["difficulty"] = difficulty
+            self.score = 0
+        def close(self):
+            pass
+
+    monkeypatch.setitem(sys.modules, "pygame", None)
+    monkeypatch.setattr(cli, "safe_run_episode", lambda env, agents: None)
+    monkeypatch.setattr(cli, "update_leaderboard", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "summary", lambda env: {})
+    monkeypatch.setattr(cli, "update_scores", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "PolePositionEnv", DummyEnv)
+    monkeypatch.setattr(sys, "argv", ["spp", "race", "--difficulty", "expert"])
+    monkeypatch.setenv("FAST_TEST", "1")
+
+    cli.main()
+    assert recorded.get("difficulty") == "expert"

--- a/tests/test_difficulty.py
+++ b/tests/test_difficulty.py
@@ -1,0 +1,29 @@
+import os
+import importlib
+
+
+def _load_env() -> None:
+    import super_pole_position.envs.pole_position as pp
+    importlib.reload(pp)
+    globals()["PolePositionEnv"] = pp.PolePositionEnv
+
+
+def test_expert_time_limit() -> None:
+    os.environ["FAST_TEST"] = "0"
+    _load_env()
+    env = PolePositionEnv(render_mode="human", difficulty="expert")
+    assert env.time_limit == 75.0
+    env.close()
+    os.environ["FAST_TEST"] = "1"
+    _load_env()
+
+
+def test_beginner_time_limit_qualify() -> None:
+    os.environ["FAST_TEST"] = "0"
+    _load_env()
+    env = PolePositionEnv(render_mode="human", mode="qualify", difficulty="beginner")
+    assert env.time_limit == 73.0
+    env.close()
+    os.environ["FAST_TEST"] = "1"
+    _load_env()
+


### PR DESCRIPTION
## Summary
- add `difficulty` parameter to `PolePositionEnv`
- allow CLI to pass `--difficulty` for qualify and race modes
- wire menu difficulty into env creation
- tick off difficulty item in progress doc and update changelog/README
- test env and CLI difficulty behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5088156883248a3d3a7da2df1900