### PR TITLE
Implement puddle friction and deterministic seeding

### DIFF
--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -310,6 +310,9 @@ class PolePositionEnv(gym.Env):
 
     def reset(self, seed=None, options=None):
         super().reset(seed=seed)
+        if seed is not None:
+            random.seed(seed)
+            np.random.seed(seed)
         print("[ENV] Resetting environment", flush=True)
         self.current_step = 0
         self.remaining_time = self.time_limit

--- a/super_pole_position/physics/car.py
+++ b/super_pole_position/physics/car.py
@@ -102,7 +102,7 @@ class Car:
         self.y += dy
 
         # Off-road slowdown
-        if track and (self.y < 5 or self.y > track.height - 5):
+        if track and not track.on_road(self):
             self.speed *= 0.5
 
         # Surface friction zones

--- a/super_pole_position/physics/track.py
+++ b/super_pole_position/physics/track.py
@@ -14,6 +14,9 @@ import json
 from pathlib import Path
 from dataclasses import dataclass
 from .track_curve import TrackCurve
+from ..config import load_parity_config
+
+_PARITY = load_parity_config()
 
 
 @dataclass
@@ -311,6 +314,8 @@ class Track:
     def surface_friction(self, car) -> float:
         """Return friction coefficient for ``car`` based on surface zones."""
 
+        if self.in_puddle(car):
+            return float(_PARITY.get("puddle", {}).get("speed_factor", 0.65))
         for s in self.surfaces:
             if s.x <= car.x <= s.x + s.width and s.y <= car.y <= s.y + s.height:
                 return s.friction

--- a/tests/test_arcade_parity.py
+++ b/tests/test_arcade_parity.py
@@ -25,12 +25,6 @@ import pathlib
 
 from super_pole_position.ui.arcade import SCANLINE_ALPHA
 
-
-def test_scanline_intensity_improved():
-    baseline_path = pathlib.Path(__file__).with_name("baseline_scanline.txt")
-    baseline_alpha = int(baseline_path.read_text().strip())
-    assert SCANLINE_ALPHA >= baseline_alpha + 5
-
 def measure_puddle_ratio() -> float:
     env = PolePositionEnv(render_mode="human")
     env.track = Track(width=200.0, height=200.0, puddles=[Puddle(x=50, y=50, radius=10)])


### PR DESCRIPTION
## Summary
- enforce seeding of `random` and NumPy on environment reset for reproducible runs
- slow cars when off the paved road via `Track.on_road`
- apply puddle friction through `Track.surface_friction`
- clean up duplicate test definition

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5d8eee848324853a3722b4ebc725