### PR TITLE
ci: stabilize tests, seed RNG fully, add headless render + packaging smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ rrrrr
 
 ## Quick Start
 ```bash
-pip install -r requirements.txt
+pip install -r requirements.txt && python run_game.py
 python press_start.py
 # or dive into the CLI
 spp qualify --agent null --track fuji

--- a/run_game.py
+++ b/run_game.py
@@ -1,0 +1,4 @@
+from super_pole_position.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[options.entry_points]
+console_scripts =
+    pole-position = super_pole_position.cli:main

--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -91,6 +91,7 @@ class PolePositionEnv(gym.Env):
         player_name: str = "PLAYER",
         slipstream: bool = True,
         difficulty: str = "beginner",
+        seed: int | None = None,
     ) -> None:
         """Create a Pole Position environment.
 
@@ -99,9 +100,13 @@ class PolePositionEnv(gym.Env):
         :param track_name: Optional track to load.
         :param hyper: If ``True`` doubles gear limits for extreme speed.
         :param player_name: Name recorded in the high-score table.
+        :param seed: Optional RNG seed for deterministic start state.
         """
 
         super().__init__()
+        if seed is not None:
+            random.seed(seed)
+            np.random.seed(seed)
         self.render_mode = render_mode
         self.mode = mode
         self.hyper = hyper
@@ -313,6 +318,7 @@ class PolePositionEnv(gym.Env):
         if seed is not None:
             random.seed(seed)
             np.random.seed(seed)
+        self._rng = random.Random(seed) if seed is not None else random
         print("[ENV] Resetting environment", flush=True)
         self.current_step = 0
         self.remaining_time = self.time_limit
@@ -379,7 +385,8 @@ class PolePositionEnv(gym.Env):
         self.step_log = []
 
         # Return initial observation
-        return self._get_obs(), {}
+        info = {"track_hash": getattr(self.track, "track_hash", lambda: "")()}
+        return self._get_obs(), info
 
     def step(self, action):
         """

--- a/super_pole_position/physics/track.py
+++ b/super_pole_position/physics/track.py
@@ -91,6 +91,24 @@ class Track:
             self._curve_lengths = list(self.curve._lengths)
 
     # ------------------------------------------------------------------
+    @staticmethod
+    def get_puddle_factor() -> float:
+        """Return slowdown factor for puddles from config."""
+
+        return float(_PARITY_CFG.get("puddle", {}).get("speed_factor", 0.65))
+
+    # ------------------------------------------------------------------
+    def track_hash(self) -> str:
+        """Return a stable hash of static track attributes."""
+
+        import hashlib
+
+        data = (
+            f"{self.width},{self.height},{self.road_width}," f"{self.segments},{self.puddles},{self.surfaces}"
+        )
+        return hashlib.sha1(data.encode()).hexdigest()
+
+    # ------------------------------------------------------------------
     # Geometry helpers
     # ------------------------------------------------------------------
     def y_at(self, x: float) -> float:
@@ -317,16 +335,7 @@ class Track:
     def surface_friction(self, car) -> float:
         """Return friction coefficient for ``car`` based on surface zones."""
         if self.in_puddle(car):
-            return float(_PARITY_CFG.get("puddle", {}).get("speed_factor", 0.65))
-
-        if self.in_puddle(car):
-            return float(_PARITY_CFG.get("puddle", {}).get("speed_factor", 0.65))
-
-        if self.in_puddle(car):
-            return float(_PARITY_CFG["puddle"].get("speed_factor", 0.65))
-
-        if self.in_puddle(car):
-            return float(_PARITY.get("puddle", {}).get("speed_factor", 0.65))
+            return self.get_puddle_factor()
         for s in self.surfaces:
             if s.x <= car.x <= s.x + s.width and s.y <= car.y <= s.y + s.height:
                 return s.friction

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -1,0 +1,20 @@
+import numpy as np
+from super_pole_position.envs.pole_position import PolePositionEnv
+
+
+def collect_obs(seed: int) -> tuple[str, bytes]:
+    env = PolePositionEnv(render_mode="human", seed=seed)
+    obs, info = env.reset(seed=seed)
+    buf = bytearray(obs.tobytes())
+    for _ in range(200):
+        obs, *_ = env.step({"throttle": 0.5, "brake": 0.0, "steer": 0.0})
+        buf.extend(obs.tobytes())
+    env.close()
+    return info.get("track_hash", ""), bytes(buf)
+
+
+def test_determinism_seeded():
+    h1, o1 = collect_obs(42)
+    h2, o2 = collect_obs(42)
+    assert h1 == h2
+    assert o1 == o2

--- a/tests/test_headless_render.py
+++ b/tests/test_headless_render.py
@@ -1,0 +1,16 @@
+import os
+import pygame
+from super_pole_position.ui.arcade import Pseudo3DRenderer
+from super_pole_position.envs.pole_position import PolePositionEnv
+
+
+def test_headless_render_smoke():
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    pygame.display.init()
+    screen = pygame.display.set_mode((256, 224))
+    renderer = Pseudo3DRenderer(screen)
+    env = PolePositionEnv(render_mode="human")
+    env.reset(seed=0)
+    renderer.draw(env)
+    pygame.display.quit()
+    env.close()

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -1,0 +1,18 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_wheel_smoke(tmp_path):
+    wheel_dir = tmp_path / "wheel"
+    wheel_dir.mkdir()
+    subprocess.check_call([sys.executable, "-m", "pip", "wheel", ".", "-w", str(wheel_dir)])
+    wheel = next(wheel_dir.glob("super_pole_position-*.whl"))
+    venv_dir = tmp_path / "venv"
+    subprocess.check_call([sys.executable, "-m", "venv", str(venv_dir)])
+    pip = venv_dir / "bin" / "pip"
+    exe = venv_dir / "bin" / "super-pole-position"
+    subprocess.check_call([str(pip), "install", str(wheel)])
+    env = {"FAST_TEST": "1", "SDL_VIDEODRIVER": "dummy", **os.environ}
+    subprocess.check_call([str(exe), "race", "--agent", "null"], env=env)


### PR DESCRIPTION
## Summary
- ensure README showcases one-line install/run command
- expose RNG seed in env constructor and return `track_hash`
- centralize puddle config via `Track.get_puddle_factor`
- add deterministic, headless render and packaging smoke tests
- package entry point via `setup.cfg` and add helper `run_game.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -X dev -bb -Werror -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b6a7a8b148324bf9fe54f8fc41ee2