### PR TITLE
Fix deterministic reset

### DIFF
--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -53,6 +53,19 @@ FAST_TEST = bool(int(os.getenv("FAST_TEST", "0")))
 PARITY_CFG = load_parity_config()
 
 
+def _seed_all(seed: int) -> None:
+    """Seed all random generators used by the environment."""
+
+    random.seed(seed)
+    np.random.seed(seed)
+    try:  # pragma: no cover - optional dependency
+        import torch  # type: ignore
+
+        torch.manual_seed(seed)
+    except Exception:
+        pass
+
+
 def ordinal(n: int) -> str:
     """Return ordinal string for an integer (1 -> 1ST)."""
     if 10 <= n % 100 <= 20:
@@ -104,8 +117,7 @@ class PolePositionEnv(gym.Env):
 
         super().__init__()
         if seed is not None:
-            random.seed(seed)
-            np.random.seed(seed)
+            _seed_all(seed)
         self.render_mode = render_mode
         self.mode = mode
         self.hyper = hyper
@@ -315,8 +327,7 @@ class PolePositionEnv(gym.Env):
     def reset(self, seed=None, options=None):
         super().reset(seed=seed)
         if seed is not None:
-            random.seed(seed)
-            np.random.seed(seed)
+            _seed_all(seed)
         print("[ENV] Resetting environment", flush=True)
         self.current_step = 0
         self.remaining_time = self.time_limit
@@ -358,6 +369,9 @@ class PolePositionEnv(gym.Env):
         self.cars[1].y = self.track.y_at(self.cars[1].x)
         self.cars[1].angle = 0.0
         self.cars[1].speed = 0.0
+
+        # Recompute track hash after state reset for determinism
+        self.track._hash = self.track._compute_hash()
 
         if self.mode == "race":
             for i, t in enumerate(self.traffic):

--- a/super_pole_position/evaluation/lap_times.py
+++ b/super_pole_position/evaluation/lap_times.py
@@ -4,10 +4,12 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import List, Dict
 from urllib import request
 
+logger = logging.getLogger(__name__)
 _DEFAULT_FILE = Path(__file__).resolve().parent / "lap_times.json"
 
 
@@ -32,7 +34,7 @@ def update_lap_times(file: Path | None, name: str, lap_ms: int) -> None:
     try:
         file.write_text(json.dumps({"laps": laps}, indent=2))
     except Exception as exc:  # pragma: no cover - file error
-        print(f"update_lap_times error: {exc}", flush=True)
+        logger.debug("update_lap_times error: %s", exc)
 
 
 def reset_lap_times(file: Path | None = None) -> None:
@@ -41,7 +43,7 @@ def reset_lap_times(file: Path | None = None) -> None:
     try:
         file.write_text(json.dumps({"laps": []}, indent=2))
     except Exception as exc:  # pragma: no cover - file error
-        print(f"reset_lap_times error: {exc}", flush=True)
+        logger.debug("reset_lap_times error: %s", exc)
 
 
 def submit_lap_time_http(
@@ -55,5 +57,5 @@ def submit_lap_time_http(
         with request.urlopen(req, timeout=1) as resp:  # pragma: no cover - network
             return 200 <= resp.status < 300
     except Exception as exc:  # pragma: no cover - network failure
-        print(f"submit_lap_time_http error: {exc}", flush=True)
+        logger.debug("submit_lap_time_http error: %s", exc)
         return False

--- a/super_pole_position/evaluation/scores.py
+++ b/super_pole_position/evaluation/scores.py
@@ -12,11 +12,13 @@ Description: Module for Super Pole Position.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import List, Dict
 from urllib import request
 
 
+logger = logging.getLogger(__name__)
 _DEFAULT_FILE = Path(__file__).resolve().parent / "scores.json"
 
 
@@ -43,7 +45,7 @@ def update_scores(file: Path | None, name: str, score: int) -> None:
     try:
         file.write_text(json.dumps({"scores": scores}, indent=2))
     except Exception as exc:  # pragma: no cover - file error
-        print(f"update_scores error: {exc}", flush=True)
+        logger.debug("update_scores error: %s", exc)
 
 
 def reset_scores(file: Path | None = None) -> None:
@@ -53,7 +55,7 @@ def reset_scores(file: Path | None = None) -> None:
     try:
         file.write_text(json.dumps({"scores": []}, indent=2))
     except Exception as exc:  # pragma: no cover - file error
-        print(f"reset_scores error: {exc}", flush=True)
+        logger.debug("reset_scores error: %s", exc)
 
 
 def submit_score_http(
@@ -71,5 +73,5 @@ def submit_score_http(
         with request.urlopen(req, timeout=1) as resp:  # pragma: no cover - network
             return 200 <= resp.status < 300
     except Exception as exc:  # pragma: no cover - network failure
-        print(f"submit_score_http error: {exc}", flush=True)
+        logger.debug("submit_score_http error: %s", exc)
         return False


### PR DESCRIPTION
## Summary
- seed torch along with numpy and random
- recompute track hash on reset
- silence score and lap submission warnings

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b73988ac88324b2aabbc86a451bbf