### PR TITLE
Ensure deterministic resets

### DIFF
--- a/super_pole_position/ai_cpu.py
+++ b/super_pole_position/ai_cpu.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 import random
+from random import Random
 
 from .physics.car import Car
 from .physics.track import Track
@@ -21,11 +22,12 @@ class CPUCar(Car):
     _block_time: float = field(default=0.0, init=False)
     _block_cooldown: float = field(default=0.0, init=False)
     _lane_timer: float = field(default=0.0, init=False)
+    rng: Random = field(default_factory=Random, repr=False)
 
     def __post_init__(self) -> None:
         super().__init__(self.x, self.y, self.angle, self.speed)
         self.preferred_lane = self.y
-        self._lane_timer = random.uniform(2.0, 4.0)
+        self._lane_timer = self.rng.uniform(2.0, 4.0)
 
     def blocking(self, player: Car, track: Track) -> bool:
         """Return ``True`` if player is close enough behind to block."""
@@ -52,11 +54,9 @@ class CPUCar(Car):
         if self.state == "CRUISE":
             self._lane_timer -= dt
             if self._lane_timer <= 0.0:
-                offset = random.choice([-1.0, 0.0, 1.0])
-                self.preferred_lane = (
-                    track.y_at(self.x) + offset
-                )
-                self._lane_timer = random.uniform(2.0, 4.0)
+                offset = self.rng.choice([-1.0, 0.0, 1.0])
+                self.preferred_lane = track.y_at(self.x) + offset
+                self._lane_timer = self.rng.uniform(2.0, 4.0)
             diff = self.preferred_lane - self.y
             self.y += diff * dt * 0.5
 

--- a/super_pole_position/evaluation/lap_times.py
+++ b/super_pole_position/evaluation/lap_times.py
@@ -7,8 +7,10 @@ import json
 from pathlib import Path
 from typing import List, Dict
 from urllib import request
+import logging
 
 _DEFAULT_FILE = Path(__file__).resolve().parent / "lap_times.json"
+logger = logging.getLogger(__name__)
 
 
 def load_lap_times(file: Path | None = None) -> List[Dict]:
@@ -55,5 +57,5 @@ def submit_lap_time_http(
         with request.urlopen(req, timeout=1) as resp:  # pragma: no cover - network
             return 200 <= resp.status < 300
     except Exception as exc:  # pragma: no cover - network failure
-        print(f"submit_lap_time_http error: {exc}", flush=True)
+        logger.debug("submit_lap_time_http error: %s", exc)
         return False

--- a/super_pole_position/evaluation/scores.py
+++ b/super_pole_position/evaluation/scores.py
@@ -15,9 +15,11 @@ import json
 from pathlib import Path
 from typing import List, Dict
 from urllib import request
+import logging
 
 
 _DEFAULT_FILE = Path(__file__).resolve().parent / "scores.json"
+logger = logging.getLogger(__name__)
 
 
 def load_scores(file: Path | None = None) -> List[Dict]:
@@ -71,5 +73,5 @@ def submit_score_http(
         with request.urlopen(req, timeout=1) as resp:  # pragma: no cover - network
             return 200 <= resp.status < 300
     except Exception as exc:  # pragma: no cover - network failure
-        print(f"submit_score_http error: {exc}", flush=True)
+        logger.debug("submit_score_http error: %s", exc)
         return False


### PR DESCRIPTION
## Summary
- seed dedicated RNGs in `PolePositionEnv` to keep resets repeatable
- route optional car AI through a seeded RNG
- silence score submission errors with debug logging

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b73988ac88324b2aabbc86a451bbf