### PR TITLE
Fix friction factor and add AI integration tests

### DIFF
--- a/super_pole_position/physics/track.py
+++ b/super_pole_position/physics/track.py
@@ -354,17 +354,13 @@ class Track:
 
     def surface_friction(self, car) -> float:
         """Return friction coefficient for ``car`` based on surface zones."""
-        return self.friction_factor(car)
+        return self.base_friction_factor(car)
 
     # ------------------------------------------------------------------
-    def friction_factor(self, obj) -> float:
-        """Return combined friction factor for ``obj``."""
+    def base_friction_factor(self, obj) -> float:
+        """Return friction factor for ``obj`` based on surface properties."""
 
         factor = 1.0
-
-        if not self.on_road(obj):
-            cfg = load_parity_config()
-            factor *= float(cfg.get("offroad_speed_factor", 0.5))
 
         if self.in_puddle(obj):
             factor *= self.get_puddle_factor()
@@ -380,9 +376,13 @@ class Track:
         """Return combined friction factor for ``car``."""
 
         factor = self.surface_friction(car)
-        off = float(_PARITY_CFG.get("offroad_factor", 0.5))
+
         if not self.on_road(car):
-            factor *= off
+            if self.in_puddle(car):
+                factor *= float(_PARITY_CFG.get("offroad_factor", 0.5))
+            else:
+                factor *= float(_PARITY_CFG.get("offroad_speed_factor", 0.5))
+
         return factor
 
     def billboard_hit(self, car) -> bool:

--- a/tests/test_ai_integration.py
+++ b/tests/test_ai_integration.py
@@ -1,0 +1,26 @@
+import pytest
+
+from super_pole_position.envs.pole_position import PolePositionEnv
+from super_pole_position.agents.openai_agent import OpenAIAgent
+from super_pole_position.agents.mistral_agent import MistralAgent
+
+
+def _run_agent(agent_cls):
+    env = PolePositionEnv(render_mode="human", mode="race")
+    env.reset()
+    agent = agent_cls()
+    for _ in range(10):
+        obs = env._get_obs()
+        action = agent.act(obs)
+        env.step(action)
+    env.close()
+
+
+def test_openai_agent_fallback(monkeypatch):
+    monkeypatch.delenv("ALLOW_NET", raising=False)
+    _run_agent(OpenAIAgent)
+
+
+def test_mistral_agent_fallback(monkeypatch):
+    monkeypatch.delenv("ALLOW_NET", raising=False)
+    _run_agent(MistralAgent)


### PR DESCRIPTION
## Summary
- fix recursion and double multiplication in track friction computation
- add regression tests for OpenAIAgent and MistralAgent fallback behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b9e40cff48324ad06ca83bf2df1a3