### PR TITLE
feat: add track-file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ spp qualify --agent null --track fuji
 spp qualify --agent null --track fuji_curve
 # record scores under your initials
 spp race --player AAA
+# load a custom track
+spp race --track-file my_track.json
 ```
 ![](docs.gif)
 

--- a/super_pole_position/cli.py
+++ b/super_pole_position/cli.py
@@ -45,6 +45,7 @@ def main() -> None:
     q = sub.add_parser("qualify")
     q.add_argument("--agent", choices=list(AGENT_MAP.keys()), default="null")
     q.add_argument("--track", default="fuji")
+    q.add_argument("--track-file", dest="track_file")
     q.add_argument("--render", action="store_true")
     q.add_argument("--mute-bgm", action="store_true", help="Disable background music")
     q.add_argument("--player", default="PLAYER", help="Name for score entry")
@@ -68,6 +69,7 @@ def main() -> None:
     r = sub.add_parser("race")
     r.add_argument("--agent", choices=list(AGENT_MAP.keys()), default="null")
     r.add_argument("--track", default="fuji")
+    r.add_argument("--track-file", dest="track_file")
     r.add_argument("--render", action="store_true")
     r.add_argument("--mute-bgm", action="store_true", help="Disable background music")
     r.add_argument("--player", default="PLAYER", help="Name for score entry")
@@ -152,6 +154,7 @@ def main() -> None:
             render_mode="human",
             mode="qualify",
             track_name=args.track,
+            track_file=args.track_file,
             player_name=args.player,
             difficulty=args.difficulty,
         )
@@ -206,6 +209,7 @@ def main() -> None:
             render_mode="human",
             mode="race",
             track_name=args.track,
+            track_file=args.track_file,
             player_name=args.player,
             difficulty=args.difficulty,
         )

--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -101,6 +101,7 @@ class PolePositionEnv(gym.Env):
         render_mode: str = "human",
         mode: str = "race",
         track_name: str | None = None,
+        track_file: str | None = None,
         hyper: bool = False,
         player_name: str = "PLAYER",
         slipstream: bool = True,
@@ -111,7 +112,8 @@ class PolePositionEnv(gym.Env):
 
         :param render_mode: ``human`` for pygame output.
         :param mode: ``race`` or ``qualify``.
-        :param track_name: Optional track to load.
+        :param track_name: Optional built-in track to load.
+        :param track_file: Path to a custom track JSON file.
         :param hyper: If ``True`` doubles gear limits for extreme speed.
         :param player_name: Name recorded in the high-score table.
         """
@@ -128,6 +130,7 @@ class PolePositionEnv(gym.Env):
         self.player_name = player_name
         self.slipstream_enabled = slipstream
         self.difficulty = difficulty
+        self.track_file = track_file
 
         limits = {
             "beginner": {"race": 90.0, "qualify": 73.0},
@@ -140,9 +143,12 @@ class PolePositionEnv(gym.Env):
             self.traffic_count = 2
 
         # Track & cars
-        self.track = (
-            Track.load(track_name) if track_name else Track(width=200.0, height=200.0)
-        )
+        if track_file:
+            self.track = Track.from_file(track_file)
+        else:
+            self.track = (
+                Track.load(track_name) if track_name else Track(width=200.0, height=200.0)
+            )
         self.cars = [Car(x=50, y=50), Car(x=150, y=150)]
         if self.hyper:
             for car in self.cars:

--- a/tests/test_cli_track_file.py
+++ b/tests/test_cli_track_file.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+import pytest  # noqa: F401
+from super_pole_position import cli
+
+
+def test_cli_track_file(monkeypatch, tmp_path):
+    recorded = {}
+
+    class DummyEnv:
+        def __init__(self, *_, track_file=None, **__):  # type: ignore
+            recorded['file'] = track_file
+            self.score = 0
+
+        def close(self):
+            pass
+
+    monkeypatch.setitem(sys.modules, "pygame", None)
+    monkeypatch.setattr(cli, "safe_run_episode", lambda env, agents: None)
+    monkeypatch.setattr(cli, "update_leaderboard", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "summary", lambda env: {})
+    monkeypatch.setattr(cli, "update_scores", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "PolePositionEnv", DummyEnv)
+    track = tmp_path / "track.json"
+    track.write_text("{}")
+    monkeypatch.setattr(sys, "argv", ["spp", "race", "--track-file", str(track)])
+    monkeypatch.setenv("FAST_TEST", "1")
+
+    cli.main()
+    assert recorded.get("file") == str(track)


### PR DESCRIPTION
## Summary
- support passing `--track-file` to CLI
- allow custom track JSON in PolePositionEnv
- document custom track usage
- test new CLI option

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest tests/test_cli_track_file.py -q` *(fails: could not import 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_685ba91da33c83249c2d6a19d7653357