### PR TITLE
Fix CLI FAST_TEST timeout

### DIFF
--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -139,8 +139,8 @@ class PolePositionEnv(gym.Env):
         self.time_limit = limits.get(difficulty, limits["beginner"])[self.mode]
         self.traffic_count = 7 if self.mode == "race" else 0
         if FAST_TEST:
-            self.time_limit = min(self.time_limit, 20.0)
-            self.traffic_count = 2
+            self.time_limit = min(self.time_limit, 3.0)
+            self.traffic_count = 1
 
         # Track & cars
         if track_file:


### PR DESCRIPTION
## Summary
- shorten FAST_TEST time limit so headless CLI mode finishes quickly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `pytest tests/test_cli_headless.py::test_cli_headless -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc0da2f588324acd9dbb8f99583a5