### PR TITLE
Make audio tests optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ entry in `config.arcade_parity.yaml`.
 - 🖥️ Python 3.8+  
 - 🏎️ Gymnasium (Reinforcement Learning framework)  
 - 🧠 PyTorch / TensorFlow (for AI models)  
-- 🎵 SimpleAudio (or fallback to Pygame's mixer)
+- 🎵 SimpleAudio or Pygame's mixer (optional, tests skip if absent)
 - 🎮 Pygame (for optional graphics)
 - 📡 ZeroMQ / WebSockets (for live AI telemetry)
 

--- a/tests/test_audio_triggers.py
+++ b/tests/test_audio_triggers.py
@@ -10,6 +10,8 @@ Description: Test suite for test_audio_triggers.
 
 import pytest  # noqa: F401
 
+pytest.importorskip("pygame", reason="pygame required for audio tests")
+
 from super_pole_position.envs.pole_position import PolePositionEnv
 
 


### PR DESCRIPTION
## Summary
- skip audio tests if pygame not installed
- clarify optional audio in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd7d8bec48324903e707d21bcf944