### PR TITLE
Enable attract mode leaderboard

### DIFF
--- a/PROGRESS_ARCADE_PARITY.md
+++ b/PROGRESS_ARCADE_PARITY.md
@@ -33,7 +33,7 @@
 - [x] Difficulty options for time allowance per lap
 - [ ] Expanded end-of-race sequence with rank display
 - [ ] Local high-score entry and leaderboard screen
-- [ ] Optional attract mode cycling the leaderboard
+- [x] Optional attract mode cycling the leaderboard
 - [x] Finish-line check when timer hits exactly zero
 - [x] Puddles placed at original track corners
 

--- a/super_pole_position/cli.py
+++ b/super_pole_position/cli.py
@@ -65,6 +65,11 @@ def main() -> None:
         default="beginner",
         help="Set difficulty level for time limits",
     )
+    q.add_argument(
+        "--attract-mode",
+        action="store_true",
+        help="Cycle leaderboard when idle at menu",
+    )
 
     r = sub.add_parser("race")
     r.add_argument("--agent", choices=list(AGENT_MAP.keys()), default="null")
@@ -89,6 +94,11 @@ def main() -> None:
         default="beginner",
         help="Set difficulty level for time limits",
     )
+    r.add_argument(
+        "--attract-mode",
+        action="store_true",
+        help="Cycle leaderboard when idle at menu",
+    )
 
     sub.add_parser("hiscore")
     sub.add_parser("reset-scores")
@@ -109,6 +119,10 @@ def main() -> None:
         os.environ["DISABLE_BRAKE"] = "1"
     else:
         os.environ.setdefault("DISABLE_BRAKE", "0")
+    if getattr(args, "attract_mode", False):
+        os.environ["ATTRACT_MODE"] = "1"
+    else:
+        os.environ.setdefault("ATTRACT_MODE", "0")
 
     if args.cmd == "hiscore":
         file = Path(__file__).parent / "evaluation" / "scores.json"

--- a/tests/test_attract_mode.py
+++ b/tests/test_attract_mode.py
@@ -1,0 +1,21 @@
+import os
+import pytest
+
+pygame = pytest.importorskip('pygame')
+from super_pole_position.ui import menu
+
+
+def test_attract_mode_cycles_scores(monkeypatch):
+    calls = []
+
+    def fake_show(screen, font):
+        calls.append(True)
+
+    monkeypatch.setattr(menu, "_show_high_scores", fake_show)
+    pygame.init()
+    screen = pygame.display.set_mode((320, 240))
+    monkeypatch.setenv("ATTRACT_MODE", "1")
+    monkeypatch.setenv("FAST_TEST", "1")
+    menu.main_loop(screen, seed=42)
+    pygame.quit()
+    assert calls


### PR DESCRIPTION
## Summary
- mark leaderboard attract mode done
- add `--attract-mode` CLI flag
- show high scores when idle if ATTRACT_MODE is set
- test attract mode cycle

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be27cb0b883248b6fb8979fd026ae