### PR TITLE
Fix tests requiring fastapi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 graphics = ["pygame"]
 ai = ["torch", "transformers"]
 dev = ["pytest", "pytest-cov", "coverage", "pytest-timeout"]
+web = ["fastapi", "httpx"]
 
 [project.scripts]
 super-pole-position = "super_pole_position.cli:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ pytest
 pytest-cov
 coverage
 pytest-timeout
+fastapi
+httpx


### PR DESCRIPTION
## Summary
- add optional `web` extras for FastAPI usage
- keep CI stable by listing FastAPI and httpx in requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bfde39ab48324a0c7712154bfd0ee