### PR TITLE
Fix TrackCurve point_at zero case

### DIFF
--- a/super_pole_position/physics/track_curve.py
+++ b/super_pole_position/physics/track_curve.py
@@ -64,6 +64,8 @@ class TrackCurve:
         if not self._points:
             return 0.0, 0.0
         s = max(0.0, min(s, self.total_length))
+        if s <= 0.0:
+            return self._points[0]
         for i, d in enumerate(self._lengths):
             if d >= s:
                 return self._points[i + 1]

--- a/tests/test_trackcurve.py
+++ b/tests/test_trackcurve.py
@@ -12,6 +12,7 @@ from super_pole_position.physics.track import Track
 def test_straight_curve():
     curve = TrackCurve.from_tuples([(0.0, 0.0, 0.0, 10.0)])
     assert curve.total_length == pytest.approx(10.0)
+    assert curve.point_at(0.0) == pytest.approx((0.0, 0.0))
     assert curve.point_at(5.0) == pytest.approx((5.0, 0.0))
     tx, ty = curve.tangent_at(5.0)
     nx, ny = curve.normal_at(5.0)


### PR DESCRIPTION
## Summary
- fix TrackCurve.point_at when distance is 0
- test start of TrackCurve

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ce456f8f0832480edd96ee5b12947