### PR TITLE
ci: gate wheel smoke test

### DIFF
--- a/docs/ci_fail_matrix.md
+++ b/docs/ci_fail_matrix.md
@@ -5,3 +5,15 @@
 | tests/test_friction_factor.py::test_surface_zone_factor | Variable `car` used instead of parameter in `Track.base_friction_factor` | Fixed | this PR |
 | tests/test_surface_friction.py::test_surface_zone_friction | Same as above causing NameError | Fixed | this PR |
 | tests/test_api_server.py::test_scores_endpoints | Missing optional dependencies `fastapi` and `httpx` | Fixed | this PR |
+```yaml
+- test: tests/test_package_smoke.py::test_wheel_smoke
+  status: pass
+  root_cause: wheel smoke test builds wheel each run
+  fix_plan: mark slow and gate behind CI_SLOW_TESTS
+  runtime: 15.38
+- test: tests/test_attract_mode.py::test_attract_mode_cycles_scores
+  status: pass
+  root_cause: attract mode cycles through high scores slowly
+  fix_plan: mark slow and gate behind CI_SLOW_TESTS if needed
+  runtime: 5.12
+```

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -1,11 +1,17 @@
+import os
 import subprocess
 import sys
 import venv
 
-
 import pytest
 
+skip_slow = pytest.mark.skipif(
+    not os.environ.get("CI_SLOW_TESTS"),
+    reason="slow test",
+)
 
+
+@skip_slow
 @pytest.mark.timeout(30)
 def test_wheel_smoke(tmp_path):
     wheel_dir = tmp_path / "wheel"


### PR DESCRIPTION
## Summary
- document slow tests in `ci_fail_matrix.md`
- skip wheel smoke test unless `CI_SLOW_TESTS` is set

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `pytest --reruns 3 -q`
- `pytest -q --durations=20`
- `ruff check .`
- `mypy --strict super_pole_position` *(fails: 193 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ceae0098c83248b915e60f3df2b7f