### PR TITLE
Fix lint warnings

### DIFF
--- a/docs/ci_fail_matrix.md
+++ b/docs/ci_fail_matrix.md
@@ -1,7 +1,17 @@
-# CI Failure Matrix
-
-| Test | Root Cause | Status | PR |
-|------|------------|--------|----|
-| tests/test_friction_factor.py::test_surface_zone_factor | Variable `car` used instead of parameter in `Track.base_friction_factor` | Fixed | this PR |
-| tests/test_surface_friction.py::test_surface_zone_friction | Same as above causing NameError | Fixed | this PR |
-| tests/test_api_server.py::test_scores_endpoints | Missing optional dependencies `fastapi` and `httpx` | Fixed | this PR |
+```yaml
+- test: tests/test_friction_factor.py::test_surface_zone_factor
+  status: fixed
+  root_cause: variable `car` used instead of parameter in Track.base_friction_factor
+- test: tests/test_surface_friction.py::test_surface_zone_friction
+  status: fixed
+  root_cause: same as above causing NameError
+- test: tests/test_api_server.py::test_scores_endpoints
+  status: fixed
+  root_cause: missing optional dependencies `fastapi` and `httpx`
+- test: tests/test_package_smoke.py::test_wheel_smoke
+  status: pass
+  runtime: 14.20
+- test: tests/test_attract_mode.py::test_attract_mode_cycles_scores
+  status: pass
+  runtime: 5.11
+```

--- a/press_start.py
+++ b/press_start.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from super_pole_position.agents.keyboard_agent import KeyboardAgent
 from super_pole_position.agents.joystick_agent import JoystickAgent
 from super_pole_position.evaluation.metrics import summary
-from super_pole_position.utils import safe_run_episode
 from super_pole_position.matchmaking.arena import run_episode
 
 try:  # optional deps may be missing on fresh installs

--- a/spp/__main__.py
+++ b/spp/__main__.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import sys
 from super_pole_position.envs.pole_position import PolePositionEnv
 
 


### PR DESCRIPTION
## Summary
- drop unused imports flagged by ruff
- refresh CI failure matrix

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `pytest --reruns 3 -q`
- `pytest -q --durations=20`
- `ruff check .`
- `mypy --strict super_pole_position spp` *(fails: 204 errors)*


------
https://chatgpt.com/codex/tasks/task_e_685ceae0098c83248b915e60f3df2b7f