### PR TITLE
ci: tidy lint errors

### DIFF
--- a/docs/ci_fail_matrix.md
+++ b/docs/ci_fail_matrix.md
@@ -5,3 +5,7 @@
 | tests/test_friction_factor.py::test_surface_zone_factor | Variable `car` used instead of parameter in `Track.base_friction_factor` | Fixed | this PR |
 | tests/test_surface_friction.py::test_surface_zone_friction | Same as above causing NameError | Fixed | this PR |
 | tests/test_api_server.py::test_scores_endpoints | Missing optional dependencies `fastapi` and `httpx` | Fixed | this PR |
+
+- test: tests/test_attract_mode.py::test_attract_mode_cycles_scores
+  status: pass
+  runtime: 5.04

--- a/press_start.py
+++ b/press_start.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from super_pole_position.agents.keyboard_agent import KeyboardAgent
 from super_pole_position.agents.joystick_agent import JoystickAgent
 from super_pole_position.evaluation.metrics import summary
-from super_pole_position.utils import safe_run_episode
 from super_pole_position.matchmaking.arena import run_episode
 
 try:  # optional deps may be missing on fresh installs

--- a/spp/__main__.py
+++ b/spp/__main__.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import sys
 from super_pole_position.envs.pole_position import PolePositionEnv
 
 


### PR DESCRIPTION
## Summary
- remove unused imports flagged by ruff
- update CI failure matrix with latest run info

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `pytest -q --durations=20`
- `mypy --strict super_pole_position` *(fails: 189 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ceae0098c83248b915e60f3df2b7f