### PR TITLE
CI pass: speed up attract mode test

### DIFF
--- a/docs/ci_fail_matrix.md
+++ b/docs/ci_fail_matrix.md
@@ -57,3 +57,8 @@
   status: pass
   runtime: 5.04
 ```
+- test: tests/test_attract_mode.py::test_attract_mode_cycles_scores
+  status: fixed
+  root_cause: idle_limit set too high under FAST_TEST causing slow loop
+  fix_plan: reduce idle_limit to 0.1 seconds when FAST_TEST=1
+  runtime: 0.15

--- a/super_pole_position/ui/menu.py
+++ b/super_pole_position/ui/menu.py
@@ -208,7 +208,7 @@ def main_loop(screen, seed: int | None = None) -> dict | None:
         tick_sfx = None
     x_offset = 0
     attract = os.getenv("ATTRACT_MODE", "0") == "1"
-    idle_limit = 5.0 if os.getenv("FAST_TEST", "0") == "1" else 10.0
+    idle_limit = 0.1 if os.getenv("FAST_TEST", "0") == "1" else 10.0
     last_input = pygame.time.get_ticks()
     running = True
     while running:


### PR DESCRIPTION
## Summary
- shorten attract mode idle time when running FAST_TEST
- record CI status for attract mode

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `pytest --reruns 3 -q`
- `pytest -q --durations=20`
- `ruff check .`
- `mypy --strict src super_pole_position` *(fails: 199 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685cfbb97cc08324a249deccad944c70