### PR TITLE
CI Triage – speed up attract mode test

### DIFF
--- a/docs/ci_fail_matrix.md
+++ b/docs/ci_fail_matrix.md
@@ -56,4 +56,7 @@
 - test: tests/test_attract_mode.py::test_attract_mode_cycles_scores
   status: pass
   runtime: 5.04
+- test: tests/test_attract_mode.py::test_attract_mode_cycles_scores
+  status: pass
+  runtime: 0.01
 ```

--- a/super_pole_position/ui/menu.py
+++ b/super_pole_position/ui/menu.py
@@ -208,7 +208,9 @@ def main_loop(screen, seed: int | None = None) -> dict | None:
         tick_sfx = None
     x_offset = 0
     attract = os.getenv("ATTRACT_MODE", "0") == "1"
-    idle_limit = 5.0 if os.getenv("FAST_TEST", "0") == "1" else 10.0
+    # When running in FAST_TEST mode we don't want to wait around for
+    # the idle timer. Use an immediate timeout so tests complete quickly.
+    idle_limit = 0.0 if os.getenv("FAST_TEST", "0") == "1" else 10.0
     last_input = pygame.time.get_ticks()
     running = True
     while running:


### PR DESCRIPTION
## Summary
- avoid idle delay during FAST_TEST runs
- update failure matrix with current runtime history

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `pytest --reruns 3 -q` *(fails: unrecognized arguments)*
- `pytest -q --durations=20`
- `ruff check .`
- `mypy --strict super_pole_position spp` *(fails: Found 199 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685cfbb97cc08324a249deccad944c70