### PR TITLE
CI triage: add episode_reward typing

### DIFF
--- a/docs/ci_fail_matrix.md
+++ b/docs/ci_fail_matrix.md
@@ -72,5 +72,10 @@
   root_cause: idle_limit set too high under FAST_TEST causing slow loop
   fix_plan: reduce idle_limit to 0.1 seconds when FAST_TEST=1
   runtime: 0.15
+- test: typing
+  status: fixed
+  root_cause: PolePositionEnv lacked episode_reward attribute
+  fix_plan: define episode_reward in env init and reset
+  runtime: 0.00
 ```
 

--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -236,6 +236,8 @@ class PolePositionEnv(gym.Env):
         self.start_phase = "READY"
         self.lap = 0
         self.score = 0.0
+        # Cumulative reward for the current episode
+        self.episode_reward: float = 0.0
         self.overtakes = 0
         self.prev_progress = 0.0
         self.prev_x = 0.0
@@ -366,6 +368,7 @@ class PolePositionEnv(gym.Env):
         self.start_phase = "READY"
         self.lap = 0
         self.score = 0.0
+        self.episode_reward = 0.0
         self.overtakes = 0
         self.prev_progress = 0.0
         self.prev_x = 0.0


### PR DESCRIPTION
## Summary
- fix missing `episode_reward` attribute in environment
- log entry in `ci_fail_matrix.md`

## Testing
- `python -m pytest -q`
- `python -m pytest -q --durations=20`
- `ruff check .`
- `mypy --strict super_pole_position spp` *(fails: 163 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d0dae460c8324abfd8362ade0e62f