### PR TITLE
CI improvement

### DIFF
--- a/docs/ci_fail_matrix.md
+++ b/docs/ci_fail_matrix.md
@@ -93,4 +93,24 @@
   root_cause: pygame not installed
   fix_plan: add pygame dependency
   runtime: 0.00
+- test: tests/test_cli_headless.py::test_cli_headless
+  status: pass
+  root_cause: CLI start-up time
+  fix_plan: mark slow and gate behind CI_SLOW_TESTS
+  runtime: 3.16
+- test: tests/test_cli_stub.py::test_cli_stub
+  status: pass
+  root_cause: CLI start-up time
+  fix_plan: mark slow and gate behind CI_SLOW_TESTS
+  runtime: 3.07
+- test: tests/test_cli_smoke.py::test_cli_smoke
+  status: pass
+  root_cause: CLI start-up time
+  fix_plan: mark slow and gate behind CI_SLOW_TESTS
+  runtime: 2.81
+- test: tests/test_ai_integration.py::test_openai_agent_fallback
+  status: pass
+  root_cause: environment spin-up
+  fix_plan: mark slow and gate behind CI_SLOW_TESTS
+  runtime: 2.78
 ```

--- a/tests/test_ai_integration.py
+++ b/tests/test_ai_integration.py
@@ -1,3 +1,5 @@
+import os
+import pytest
 from super_pole_position.envs.pole_position import PolePositionEnv
 from super_pole_position.agents.openai_agent import OpenAIAgent
 from super_pole_position.agents.mistral_agent import MistralAgent
@@ -14,11 +16,13 @@ def _run_agent(agent_cls):
     env.close()
 
 
-def test_openai_agent_fallback(monkeypatch):
+@pytest.mark.skipif(not os.getenv("CI_SLOW_TESTS"), reason="slow test")
+def test_openai_agent_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("ALLOW_NET", raising=False)
     _run_agent(OpenAIAgent)
 
 
-def test_mistral_agent_fallback(monkeypatch):
+@pytest.mark.skipif(not os.getenv("CI_SLOW_TESTS"), reason="slow test")
+def test_mistral_agent_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("ALLOW_NET", raising=False)
     _run_agent(MistralAgent)

--- a/tests/test_cli_headless.py
+++ b/tests/test_cli_headless.py
@@ -8,13 +8,14 @@ test_cli_headless.py
 Description: Test suite for test_cli_headless.
 """
 
-import pytest  # noqa: F401
 import os
 import subprocess
 import sys
+import pytest
 
 
-def test_cli_headless():
+@pytest.mark.skipif(not os.getenv("CI_SLOW_TESTS"), reason="slow test")
+def test_cli_headless() -> None:
     result = subprocess.run(
         [sys.executable, "-m", "super_pole_position.cli", "race"],
         env={**os.environ, "FAST_TEST": "1"},

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,8 +1,10 @@
 import os
 import sys
 import subprocess
+import pytest
 
 
+@pytest.mark.skipif(not os.getenv("CI_SLOW_TESTS"), reason="slow test")
 def test_cli_smoke() -> None:
     result = subprocess.run(
         [sys.executable, "-m", "spp", "--headless", "--steps", "3"],

--- a/tests/test_cli_stub.py
+++ b/tests/test_cli_stub.py
@@ -1,8 +1,11 @@
+import os
 import subprocess
 import sys
+import pytest
 
 
-def test_cli_stub():
+@pytest.mark.skipif(not os.getenv("CI_SLOW_TESTS"), reason="slow test")
+def test_cli_stub() -> None:
     result = subprocess.run(
         [sys.executable, "-m", "spp", "--headless", "--steps", "3"],
         timeout=5,


### PR DESCRIPTION
## Summary
- mark CLI and integration tests as slow using `CI_SLOW_TESTS`
- record slow test runtimes in `ci_fail_matrix.md`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `pytest --reruns 3 -q`
- `pytest -q --durations=20`
- `ruff check .`
- `mypy --strict .` *(fails: Function is missing a type annotation)*

------
https://chatgpt.com/codex/tasks/task_e_685d174afdbc8324ab2694b7fd47a358