### PR TITLE
CI green improvements

### DIFF
--- a/docs/ci_fail_matrix.md
+++ b/docs/ci_fail_matrix.md
@@ -117,3 +117,11 @@
   fix_plan: mark slow and gate behind CI_SLOW_TESTS
   runtime: 2.78
 ```
+
+- run: 2025-06-26
+  status: all-pass
+  runtime: 1.71
+
+- run: 2025-06-26-a
+  status: all-pass
+  runtime: 1.00

--- a/super_pole_position/envs/pole_position.py
+++ b/super_pole_position/envs/pole_position.py
@@ -31,6 +31,7 @@ from ..physics.track import Track
 from ..physics.traffic_car import TrafficCar
 import random
 from random import Random
+from typing import Any
 from ..ai_cpu import CPUCar
 from ..agents.controllers import GPTPlanner, LowLevelController, LearningAgent
 from ..ui.arcade import Pseudo3DRenderer
@@ -347,7 +348,9 @@ class PolePositionEnv(gym.Env):
                 print(f"Load failed: {exc}", flush=True)
 
 
-    def reset(self, seed=None, options=None):
+    def reset(
+        self, seed: int | None = None, options: dict | None = None
+    ) -> tuple[np.ndarray, dict]:
         super().reset(seed=seed)
         _seed_all(seed)
         print("[ENV] Resetting environment", flush=True)
@@ -429,7 +432,7 @@ class PolePositionEnv(gym.Env):
         info = {"track_hash": self.track.track_hash}
         return obs, info
 
-    def step(self, action):
+    def step(self, action: Any) -> tuple[np.ndarray, float, bool, bool, dict]:
         """
         Step the environment.
 
@@ -1092,7 +1095,7 @@ class PolePositionEnv(gym.Env):
         except Exception:  # pragma: no cover - audio may fail
             pass
 
-    def close(self):
+    def close(self) -> None:
         """Clean up resources like audio streams."""
         if self.audio_stream is not None:
             try:

--- a/tests/test_cli_difficulty.py
+++ b/tests/test_cli_difficulty.py
@@ -3,14 +3,15 @@ import pytest  # noqa: F401
 from super_pole_position import cli
 
 
-def test_cli_difficulty_option(monkeypatch):
+def test_cli_difficulty_option(monkeypatch: pytest.MonkeyPatch) -> None:
     recorded = {}
 
     class DummyEnv:
-        def __init__(self, *_, difficulty="beginner", **__):
+        def __init__(self, *_, difficulty: str = "beginner", **__):
             recorded["difficulty"] = difficulty
             self.score = 0
-        def close(self):
+
+        def close(self) -> None:
             pass
 
     monkeypatch.setitem(sys.modules, "pygame", None)

--- a/tests/test_cli_mute_bgm.py
+++ b/tests/test_cli_mute_bgm.py
@@ -4,11 +4,11 @@ import pytest  # noqa: F401
 from super_pole_position import cli
 
 
-def fake_run_episode(env, agents):
+def fake_run_episode(env: object, agents: object) -> float:
     return 0.0
 
 
-def test_cli_mute_bgm(monkeypatch):
+def test_cli_mute_bgm(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setitem(sys.modules, "pygame", None)
     monkeypatch.setattr(cli, "run_episode", fake_run_episode)
     monkeypatch.setattr(sys, "argv", ["spp", "qualify", "--mute-bgm"])

--- a/tests/test_cli_no_brake.py
+++ b/tests/test_cli_no_brake.py
@@ -4,11 +4,11 @@ import pytest  # noqa: F401
 from super_pole_position import cli
 
 
-def fake_run_episode(env, agents):
+def fake_run_episode(env: object, agents: object) -> float:
     return 0.0
 
 
-def test_cli_no_brake(monkeypatch):
+def test_cli_no_brake(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setitem(sys.modules, "pygame", None)
     monkeypatch.setattr(cli, "run_episode", fake_run_episode)
     monkeypatch.setattr(sys, "argv", ["spp", "race", "--no-brake"])

--- a/tests/test_cli_outro.py
+++ b/tests/test_cli_outro.py
@@ -3,7 +3,7 @@ import pytest  # noqa: F401
 from super_pole_position import cli
 
 
-def test_cli_invokes_outro(monkeypatch):
+def test_cli_invokes_outro(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = []
 
     class DummyEnv:
@@ -11,7 +11,7 @@ def test_cli_invokes_outro(monkeypatch):
             self.score = 123
             self.screen = None
 
-        def close(self):
+        def close(self) -> None:
             pass
 
     monkeypatch.setitem(sys.modules, "pygame", None)

--- a/tests/test_cli_player_name.py
+++ b/tests/test_cli_player_name.py
@@ -9,7 +9,7 @@ import pytest  # noqa: F401
 from super_pole_position import cli
 
 
-def test_cli_player_name(monkeypatch):
+def test_cli_player_name(monkeypatch: pytest.MonkeyPatch) -> None:
     recorded = {}
 
     class DummyEnv:
@@ -17,7 +17,7 @@ def test_cli_player_name(monkeypatch):
             recorded["name"] = player_name
             self.score = 0
 
-        def close(self):
+        def close(self) -> None:
             pass
 
     monkeypatch.setitem(sys.modules, "pygame", None)


### PR DESCRIPTION
## Summary
- type annotate CLI tests
- add return hints to `PolePositionEnv`
- log latest CI run in failure matrix

## Testing
- `pytest -q`
- `pytest --reruns 3 -q`
- `pytest -q --durations=20`
- `ruff check .`
- `mypy --strict tests/test_cli_player_name.py`

------
https://chatgpt.com/codex/tasks/task_e_685d2700b8c08324b1fbd0dc70d3fb8d