### PR TITLE
ci: C: speed up puddle test

### DIFF
--- a/docs/ci_fail_matrix.md
+++ b/docs/ci_fail_matrix.md
@@ -135,4 +135,5 @@
 - run: 2025-06-26-a
   status: all-pass
   runtime: 1.00
-```
+- test: tests/test_arcade_parity.py::test_puddle_slowdown_improved
+  status: done

--- a/docs/ci_history/2025-06-27-1.yaml
+++ b/docs/ci_history/2025-06-27-1.yaml
@@ -1,0 +1,9 @@
+fail: 0
+xfail: 0
+skip: 8
+slow: [test_audio_triggers.py::test_prepare_voice_on_reset, test_api_server.py::test_scores_endpoints]
+coverage: 79
+lint_errors: 0
+mypy_errors: 313
+wheel_kb: 235
+mem_delta_mb: NA

--- a/docs/ci_history/2025-06-27.yaml
+++ b/docs/ci_history/2025-06-27.yaml
@@ -1,0 +1,9 @@
+fail: 0
+xfail: 0
+skip: 8
+slow: [test_arcade_parity.py::test_puddle_slowdown_improved, test_api_server.py::test_scores_endpoints]
+coverage: 80
+lint_errors: 0
+mypy_errors: 313
+wheel_kb: 122
+mem_delta_mb: NA

--- a/tests/test_arcade_parity.py
+++ b/tests/test_arcade_parity.py
@@ -17,21 +17,21 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from super_pole_position.envs.pole_position import PolePositionEnv
+from super_pole_position.physics.car import Car
 from super_pole_position.physics.track import Track, Puddle
 
 
 
 
 def measure_puddle_ratio() -> float:
-    env = PolePositionEnv(render_mode="human")
-    env.track = Track(width=200.0, height=200.0, puddles=[Puddle(x=50, y=50, radius=10)])
-    env.reset()
-    env.cars[0].y = 50
-    env.step({"throttle": True, "brake": False, "steer": 0.0})
-    pre = env.cars[0].speed
-    env.step({"throttle": False, "brake": False, "steer": 0.0})
-    post = env.cars[0].speed
+    """Return slowdown ratio when a car drives through a puddle."""
+
+    track = Track(width=200.0, height=200.0, puddles=[Puddle(x=50, y=50, radius=10)])
+    car = Car(x=50, y=50)
+    car.apply_controls(throttle=1.0, brake=0.0, steering=0.0, track=track, dt=1.0)
+    pre = car.speed
+    car.apply_controls(throttle=0.0, brake=0.0, steering=0.0, track=track, dt=1.0)
+    post = car.speed
     return post / pre
 
 


### PR DESCRIPTION
## Summary
- use Car physics directly for puddle slowdown test
- log CI metrics for latest run
- mark task done in failure matrix

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `pytest -q --reruns 3`
- `pytest -q --durations=25 --cov`
- `ruff check .`
- `mypy --strict . --exclude build` (fails: 313 errors)
- `python -m build --sdist --wheel`
- `python scripts/mem_leak_check.py --steps 300` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dede1f6748324b78bd9bd08adb48b