### PR TITLE
Fix CI test imports and tidy optional agent typing

### DIFF
--- a/super_pole_position/agents/mistral_agent.py
+++ b/super_pole_position/agents/mistral_agent.py
@@ -13,14 +13,17 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from .base_llm_agent import BaseLLMAgent, NullAgent
 
 try:
     from mistralai.client import MistralClient
-except Exception:  # pragma: no cover
+except Exception:  # pragma: no cover - optional dependency
     MistralClient = None
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from mistralai.client import MistralClient as _MistralClient  # noqa: F401
 
 
 class MistralAgent(BaseLLMAgent):
@@ -35,7 +38,7 @@ class MistralAgent(BaseLLMAgent):
             MistralClient(os.getenv("MISTRAL_API_KEY")) if self._enabled else None
         )
 
-    def act(self, observation: Any) -> dict:
+    def act(self, observation: Any) -> dict[str, float | int]:
         """Query the model and return an action dict."""
 
         if not self._enabled or self.client is None:

--- a/super_pole_position/agents/openai_agent.py
+++ b/super_pole_position/agents/openai_agent.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any, Dict
+from typing import Any, Dict, TYPE_CHECKING
 
 from .base_llm_agent import BaseLLMAgent, NullAgent
 
@@ -41,6 +41,9 @@ try:  # pragma: no cover - the import is environment-dependent
     import openai
 except Exception:  # pragma: no cover - handled by falling back to ``None``
     openai = None
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    import openai as _openai  # noqa: F401
 
 
 class OpenAIAgent(BaseLLMAgent):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,13 @@ conftest.py
 Description: Test suite for conftest.
 """
 
+import sys
+from pathlib import Path
+
 import pytest  # noqa: F401
+
+# Ensure project root is on ``sys.path`` so the local gymnasium module is found
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 # Skip the entire suite if gymnasium is unavailable
 pytest.importorskip("gymnasium")


### PR DESCRIPTION
## Summary
- ensure project root is on `sys.path` for tests
- mark optional dependencies as TYPE_CHECKING-only imports
- type annotate MistralAgent `act` return

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `ruff check super_pole_position tests`


------
https://chatgpt.com/codex/tasks/task_e_685e37f5554483249fe88cc83dc6bdd9