### PR TITLE
Fix CI test warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,5 +45,3 @@ line-length = 88
 [tool.black]
 line-length = 88
 
-[tool.pytest.ini_options]
-timeout = 10

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -12,7 +12,6 @@ skip_slow = pytest.mark.skipif(
 
 
 @skip_slow
-@pytest.mark.timeout(30)
 def test_wheel_smoke(tmp_path):
     wheel_dir = tmp_path / "wheel"
     wheel_dir.mkdir()


### PR DESCRIPTION
## Summary
- drop pytest-timeout configuration
- remove timeout mark from packaging test

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e37f5554483249fe88cc83dc6bdd9