### PR TITLE
Fix pytest warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,5 +45,3 @@ line-length = 88
 [tool.black]
 line-length = 88
 
-[tool.pytest.ini_options]
-timeout = 10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,3 +60,12 @@ try:
     ArcadeRenderer.draw = lambda self, env: None
 except Exception:
     pass
+
+
+def pytest_configure(config):
+    """Register custom markers when optional plugins are missing."""
+    if not config.pluginmanager.hasplugin("timeout"):
+        config.addinivalue_line(
+            "markers",
+            "timeout(timeout): no-op marker, pytest-timeout not installed",
+        )


### PR DESCRIPTION
## Summary
- register timeout mark when pytest-timeout isn't installed
- drop unused pytest timeout setting

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e37f5554483249fe88cc83dc6bdd9