### PR TITLE
Fix gear shift counter

### DIFF
--- a/src/physics/car.py
+++ b/src/physics/car.py
@@ -59,13 +59,15 @@ class Car:
 
     # ------------------------------------------------------------------
     def shift_high(self) -> None:
-        self.gear = "HIGH"
-        self.shift_count += 1
+        if self.gear != "HIGH":
+            self.gear = "HIGH"
+            self.shift_count += 1
 
     # ------------------------------------------------------------------
     def shift_low(self) -> None:
-        self.gear = "LOW"
-        self.shift_count += 1
+        if self.gear != "LOW":
+            self.gear = "LOW"
+            self.shift_count += 1
 
 
 """

--- a/super_pole_position/physics/car.py
+++ b/super_pole_position/physics/car.py
@@ -54,11 +54,15 @@ class Car:
 
     def shift(self, change: int) -> bool:
         """Change gear by ``change`` amount and return ``True`` if shifted."""
-        if change:
+
+        if change == 0:
+            return False
+
+        prev = self.gear
+        self.gear = min(max(self.gear + change, 0), len(self.gear_max) - 1)
+        if self.gear != prev:
             self.shift_count += 1
-            prev = self.gear
-            self.gear = min(max(self.gear + change, 0), len(self.gear_max) - 1)
-            return self.gear != prev
+            return True
         return False
 
     def apply_controls(

--- a/tests/physics/test_car_physics.py
+++ b/tests/physics/test_car_physics.py
@@ -43,3 +43,11 @@ def test_shift_count_increments():
     assert car.shift_count == 1
     car.shift_low()
     assert car.shift_count == 2
+
+
+def test_shift_count_no_increment_when_unchanged():
+    car = Car()
+    car.shift_high()
+    before = car.shift_count
+    car.shift_high()
+    assert car.shift_count == before

--- a/tests/test_gear_shift.py
+++ b/tests/test_gear_shift.py
@@ -38,3 +38,11 @@ def test_env_shift_increments_once():
     after = env.cars[0].shift_count
     assert after - before == 1
     env.close()
+
+
+def test_shift_no_increment_at_limit():
+    car = Car()
+    car.shift(1)
+    before = car.shift_count
+    car.shift(1)
+    assert car.shift_count == before


### PR DESCRIPTION
## Summary
- handle repeated gear shifts without incrementing the counter
- ensure Car dataclass shift methods check for actual changes
- test that shift count doesn't grow when already in the same gear

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e3fa8fc048324aeaaa0fbdc629cbd