### PR TITLE
Fix puddle config type handling

### DIFF
--- a/super_pole_position/config.py
+++ b/super_pole_position/config.py
@@ -38,7 +38,11 @@ def load_parity_config() -> dict[str, Any]:
             data = {}
     cfg = DEFAULTS | data
     if "puddle" in data:
-        cfg["puddle"] = DEFAULTS["puddle"] | data.get("puddle", {})
+        puddle = data.get("puddle", {})
+        if isinstance(puddle, dict):
+            cfg["puddle"] = DEFAULTS["puddle"] | puddle
+        else:
+            cfg["puddle"] = DEFAULTS["puddle"]
     if "audio_volume" in data:
         try:
             cfg["audio_volume"] = float(data["audio_volume"])


### PR DESCRIPTION
## Summary
- handle invalid non-dict `puddle` entries when loading arcade parity config

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e3fa8fc048324aeaaa0fbdc629cbd