### PR TITLE
Fix unused import

### DIFF
--- a/scripts/build_standalone.py
+++ b/scripts/build_standalone.py
@@ -1,6 +1,5 @@
 import argparse
 from pathlib import Path
-import shutil
 import zipfile
 
 


### PR DESCRIPTION
## Summary
- remove unused `shutil` import from build script

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e3fa8fc048324aeaaa0fbdc629cbd