### PR TITLE
Fix scoreboard file handling

### DIFF
--- a/super_pole_position/evaluation/lap_times.py
+++ b/super_pole_position/evaluation/lap_times.py
@@ -34,6 +34,7 @@ def update_lap_times(file: Path | None, name: str, lap_ms: int) -> None:
     laps.append({"name": name, "lap_ms": int(lap_ms)})
     laps = sorted(laps, key=lambda s: s["lap_ms"])[:10]
     try:
+        file.parent.mkdir(parents=True, exist_ok=True)
         file.write_text(json.dumps({"laps": laps}, indent=2))
     except Exception as exc:  # pragma: no cover - file error
         logger.debug("update_lap_times error: %s", exc)
@@ -43,6 +44,7 @@ def reset_lap_times(file: Path | None = None) -> None:
     """Clear all lap times in ``file``."""
     file = file or _DEFAULT_FILE
     try:
+        file.parent.mkdir(parents=True, exist_ok=True)
         file.write_text(json.dumps({"laps": []}, indent=2))
     except Exception as exc:  # pragma: no cover - file error
         logger.debug("reset_lap_times error: %s", exc)

--- a/super_pole_position/evaluation/scores.py
+++ b/super_pole_position/evaluation/scores.py
@@ -44,6 +44,7 @@ def update_scores(file: Path | None, name: str, score: int) -> None:
     scores.append({"name": name, "score": int(score)})
     scores = sorted(scores, key=lambda s: -s["score"])[:10]
     try:
+        file.parent.mkdir(parents=True, exist_ok=True)
         file.write_text(json.dumps({"scores": scores}, indent=2))
     except Exception as exc:  # pragma: no cover - file error
         logger.debug("update_scores error: %s", exc)
@@ -54,6 +55,7 @@ def reset_scores(file: Path | None = None) -> None:
 
     file = file or _DEFAULT_FILE
     try:
+        file.parent.mkdir(parents=True, exist_ok=True)
         file.write_text(json.dumps({"scores": []}, indent=2))
     except Exception as exc:  # pragma: no cover - file error
         logger.debug("reset_scores error: %s", exc)


### PR DESCRIPTION
## Summary
- ensure directories exist when writing high scores and lap times

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest tests/test_parse_action.py tests/test_menu_config.py -q` *(fails: could not import 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_685e5202f30083249a565a04d593a660