### PR TITLE
Fix player sprite visibility and restore camera

### DIFF
--- a/PROGRESS_ARCADE_PARITY.md
+++ b/PROGRESS_ARCADE_PARITY.md
@@ -4,6 +4,7 @@
 
 - [x] Pseudo-3D track with a vanishing-point horizon that sways on curves
 - [x] Raster display emulating the 256×224 resolution and broad color palette
+- [x] Internal 256×224 canvas scaled up for crisp pixels
 - [x] Scrolling playfield built from scanline-aligned segments
 - [x] Sprite scaling so cars and signboards grow smoothly when approaching
 - [x] Full-color scenery and billboards that shrink toward the horizon

--- a/super_pole_position/agents/keyboard_agent.py
+++ b/super_pole_position/agents/keyboard_agent.py
@@ -74,6 +74,14 @@ class KeyboardAgent(BaseLLMAgent):
         self._last_up = shift_up
         self._last_down = shift_down
 
+        speed = 0.0
+        try:
+            speed = float(observation[2])
+        except Exception:
+            pass
+        if gear == 0 and speed > 54.0 * 0.9:
+            gear = 1
+
         return {
             "throttle": throttle,
             "brake": brake,

--- a/super_pole_position/ui/arcade.py
+++ b/super_pole_position/ui/arcade.py
@@ -281,17 +281,12 @@ class Pseudo3DRenderer:
         self.screen = screen
         if pygame and not pygame.font.get_init():
             pygame.font.init()
-        self.render_scale = 2
+        self.internal_res = (256, 224)
         if pygame:
-            self.offscreen = pygame.Surface(
-                (
-                    screen.get_width() * self.render_scale,
-                    screen.get_height() * self.render_scale,
-                )
-            )
+            self.canvas = pygame.Surface(self.internal_res, pygame.SRCALPHA)
         else:
-            self.offscreen = None
-        self.horizon_base = int(screen.get_height() * 0.4)
+            self.canvas = None
+        self.horizon_base = int(self.internal_res[1] * 0.4)
         self.horizon = self.horizon_base
         # Sky gradient colors roughly matching the arcade palette
         self.sky_top = Palette.sky_blue
@@ -335,11 +330,9 @@ class Pseudo3DRenderer:
             self._scanline_row = pygame.Surface((1, 1), pygame.SRCALPHA)
             self._scanline_row.fill((0, 0, 0, self.scanline_alpha))
             self.start_font = pygame.font.SysFont(None, 48)
-            self.canvas = self.offscreen
         else:
             self._scanline_row = None
             self.start_font = None
-            self.canvas = screen
         self.dash_offset = 0.0
 
     def draw_explosion(self, env, pos) -> int:
@@ -379,7 +372,6 @@ class Pseudo3DRenderer:
         """Return trapezoid points for the road given ``offset``."""
 
         surface = self.canvas
-        scale = self.render_scale if self.offscreen else 1
         width = surface.get_width()
         height = surface.get_height()
         road_w = width * 0.6
@@ -390,7 +382,7 @@ class Pseudo3DRenderer:
             (width / 2 + offset + road_top / 2, self.horizon),
             (width / 2 + offset - road_top / 2, self.horizon),
         ]
-        return [(x / scale, y / scale) for x, y in points]
+        return points
 
     def draw_road_polygon(self, env) -> list[tuple[float, float]]:
         """Draw the road trapezoid and return its points."""
@@ -402,17 +394,11 @@ class Pseudo3DRenderer:
             dist = car.x
         angle = env.track.angle_at(dist)
         curvature = max(-1.0, min(angle / (math.pi / 4), 1.0))
-        offset = curvature * (self.canvas.get_width() / 4)
+        sway = getattr(env, "last_steer", 0.0) * 0.12 * self.canvas.get_width()
+        offset = curvature * (self.canvas.get_width() / 4) + sway
         points = self.road_polygon(offset)
         if pygame:
-            scaled = [
-                (
-                    x * (self.render_scale if self.offscreen else 1),
-                    y * (self.render_scale if self.offscreen else 1),
-                )
-                for x, y in points
-            ]
-            pygame.draw.polygon(self.canvas, (60, 60, 60), scaled)
+            pygame.draw.polygon(self.canvas, (60, 60, 60), points)
         return points
 
     def _draw_sky(self, surface: "pygame.Surface") -> None:
@@ -596,6 +582,29 @@ class Pseudo3DRenderer:
             else:
                 pygame.draw.rect(surface, self.car_color, rect)
 
+        # Draw the player's car fixed to the bottom center
+        player_w = 32
+        player_h = 32
+        steer = getattr(env, "last_steer", 0.0)
+        rect = pygame.Rect(
+            width // 2 - player_w // 2,
+            bottom - player_h - 2,
+            player_w,
+            player_h,
+        )
+        sprite = self.player_car_sprite
+        if abs(steer) > 0.5:
+            sprite = self.player_car_right if steer > 0 else self.player_car_left or sprite
+        if sprite:
+            img = pygame.transform.scale(sprite, (player_w, player_h))
+            if abs(steer) > 0.5:
+                angle = -15 if steer > 0 else 15
+                img = pygame.transform.rotate(img, angle)
+                rect = img.get_rect(center=rect.center)
+            surface.blit(img, rect)
+        else:
+            pygame.draw.rect(surface, self.car_color, rect)
+
         if env.mode == "race" and env.crash_timer > 0:
             self.draw_explosion(env, (int(x - car_w), int(y - car_h * 2)))
 
@@ -692,11 +701,9 @@ class Pseudo3DRenderer:
 
         # Scale to display and apply scanlines
         target = self.screen
-        if self.offscreen:
-            scaled = pygame.transform.smoothscale(self.offscreen, target.get_size())
+        if pygame:
+            scaled = pygame.transform.scale(self.canvas, target.get_size())
             target.blit(scaled, (0, 0))
-        else:
-            target = surface
 
         if self._scanline_row:
             row = pygame.transform.scale(self._scanline_row, (target.get_width(), 1))

--- a/super_pole_position/ui/sprites.py
+++ b/super_pole_position/ui/sprites.py
@@ -89,7 +89,10 @@ def load_sprite(name: str, ascii_art: list[str] | None = None) -> "pygame.Surfac
     """
 
     if not pygame:
-        return ascii_surface(ascii_art or [])
+        surf = ascii_surface(ascii_art or [])
+        if surf and (surf.get_width() < 32 or surf.get_height() < 32):
+            surf = pygame.transform.scale(surf, (32, 32))
+        return surf
     base = os.getenv("SPRITE_DIR")
     if base:
         path = Path(base) / f"{name}.png"
@@ -108,11 +111,12 @@ def load_sprite(name: str, ascii_art: list[str] | None = None) -> "pygame.Surfac
                 except Exception:
                     pass
 
+    surf = None
     if path.exists() and path.stat().st_size > 0:
         try:
-            return pygame.image.load(str(path))
+            surf = pygame.image.load(str(path))
         except Exception:
-            return ascii_surface(ascii_art or [])
+            surf = None
     else:
         # attempt to generate placeholder sprite on the fly
         gen = path.parent / "generate_placeholders.py"
@@ -133,7 +137,12 @@ def load_sprite(name: str, ascii_art: list[str] | None = None) -> "pygame.Surfac
                 pass
             if path.exists() and path.stat().st_size > 0:
                 try:
-                    return pygame.image.load(str(path))
+                    surf = pygame.image.load(str(path))
                 except Exception:
-                    pass
-    return ascii_surface(ascii_art or [])
+                    surf = None
+
+    if surf is None:
+        surf = ascii_surface(ascii_art or [])
+    if surf and (surf.get_width() < 32 or surf.get_height() < 32):
+        surf = pygame.transform.scale(surf, (32, 32))
+    return surf

--- a/tests/test_playable.py
+++ b/tests/test_playable.py
@@ -1,0 +1,22 @@
+import os
+import pytest
+
+pygame = pytest.importorskip("pygame")
+
+from super_pole_position.envs.pole_position import PolePositionEnv
+
+
+def test_player_sprite_visible() -> None:
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    pygame.display.init()
+    env = PolePositionEnv(render_mode="human")
+    env.reset(seed=7)
+    for _ in range(30):
+        env.step(env.action_space.sample())
+    env.render()
+    surface = env.screen
+    assert surface is not None
+    w, h = surface.get_size()
+    sample = surface.get_at((w // 2, int(h * 0.9)))
+    assert sample.r > 150 and sample.g < 50
+    pygame.display.quit()

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -12,11 +12,12 @@ def test_draw_road_polygon_offset():
     env = types.SimpleNamespace(
         cars=[types.SimpleNamespace(angle=0.0, steering=0.5, x=0.0)],
         track=types.SimpleNamespace(angle_at=lambda x: math.pi / 8),
+        last_steer=0.5,
     )
     poly = renderer.draw_road_polygon(env)
-    width = screen.get_width()
+    width = renderer.canvas.get_width()
     road_top = width * 0.6 * 0.2
-    expected = 0.5 * (width / 4)
+    expected = 0.5 * (width / 4) + 0.5 * 0.12 * width
     assert poly[2][0] == pytest.approx(width / 2 + expected + road_top / 2)
     assert poly[3][0] == pytest.approx(width / 2 + expected - road_top / 2)
     pygame.display.quit()

--- a/tests/test_sprite_loader.py
+++ b/tests/test_sprite_loader.py
@@ -12,5 +12,5 @@ def test_load_sprite_png(tmp_path, monkeypatch):
     pygame.image.save(img, str(fname))
     monkeypatch.setenv("SPRITE_DIR", str(tmp_path))
     surf = load_sprite("sample")
-    assert surf.get_size() == (4, 4)
+    assert surf.get_width() >= 4 and surf.get_height() >= 4
     pygame.display.quit()

--- a/tests/test_sprite_size.py
+++ b/tests/test_sprite_size.py
@@ -1,0 +1,12 @@
+import pytest
+
+pygame = pytest.importorskip("pygame")
+
+from super_pole_position.ui import sprites
+
+
+def test_player_sprite_size() -> None:
+    pygame.display.init()
+    surf = sprites.load_sprite("player_car", ascii_art=sprites.CAR_ART)
+    assert surf.get_width() >= 32 and surf.get_height() >= 32
+    pygame.display.quit()


### PR DESCRIPTION
## Summary
- ensure placeholder sprites scale to at least 32×32
- draw scene on 256×224 internal canvas and upscale once
- sway horizon with steering and keep player car bottom‑center
- auto-shift keyboard agent when speed nears max
- add tests for sprite size and player visibility
- document the internal canvas in progress log

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603d28388083249f1e2ca3d3bc30a1