### PR TITLE
Render fixes with internal canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Press **Enter** to begin or **Esc** to quit.
 🖼️ **Retro ASCII sprites** for cars, billboards and explosions.
 🎨 **Placeholder PNGs** stored in `assets/sprites` for arcade-faithful builds.
 These are zero-byte stubs included only so the file paths exist.
+🖼️ **Crisp pixels** via a 256×224 internal canvas scaled to your window.
 🚀 **Hyper Mode** for uncapped speed and obstacle chaos.
 🕹️ **Arcade-accurate mechanics**: slipstream boost, off-road slowdown, crash penalties
 🛞 **Two-speed gearbox with torque kick**

--- a/super_pole_position/agents/keyboard_agent.py
+++ b/super_pole_position/agents/keyboard_agent.py
@@ -74,6 +74,13 @@ class KeyboardAgent(BaseLLMAgent):
         self._last_up = shift_up
         self._last_down = shift_down
 
+        try:
+            speed = float(observation[2])  # type: ignore[index]
+        except Exception:
+            speed = 0.0
+        if speed > 48.0 and gear == 0:
+            gear = 1
+
         return {
             "throttle": throttle,
             "brake": brake,

--- a/super_pole_position/ui/sprites.py
+++ b/super_pole_position/ui/sprites.py
@@ -108,13 +108,13 @@ def load_sprite(name: str, ascii_art: list[str] | None = None) -> "pygame.Surfac
                 except Exception:
                     pass
 
+    surf: "pygame.Surface | None" = None
     if path.exists() and path.stat().st_size > 0:
         try:
-            return pygame.image.load(str(path))
+            surf = pygame.image.load(str(path)).convert_alpha()
         except Exception:
-            return ascii_surface(ascii_art or [])
+            surf = None
     else:
-        # attempt to generate placeholder sprite on the fly
         gen = path.parent / "generate_placeholders.py"
         if gen.exists() and not pygame.display.get_init():
             try:
@@ -133,7 +133,16 @@ def load_sprite(name: str, ascii_art: list[str] | None = None) -> "pygame.Surfac
                 pass
             if path.exists() and path.stat().st_size > 0:
                 try:
-                    return pygame.image.load(str(path))
+                    surf = pygame.image.load(str(path)).convert_alpha()
                 except Exception:
-                    pass
-    return ascii_surface(ascii_art or [])
+                    surf = None
+    if surf is None:
+        surf = ascii_surface(ascii_art or [])
+        if surf is None:
+            return None
+    w, h = surf.get_size()
+    if w < 32 or h < 32:
+        padded = pygame.Surface((32, 32), pygame.SRCALPHA)
+        padded.blit(surf, ((32 - w) // 2, (32 - h) // 2))
+        surf = padded
+    return surf

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -14,7 +14,7 @@ def test_draw_road_polygon_offset():
         track=types.SimpleNamespace(angle_at=lambda x: math.pi / 8),
     )
     poly = renderer.draw_road_polygon(env)
-    width = screen.get_width()
+    width = renderer.canvas.get_width()
     road_top = width * 0.6 * 0.2
     expected = 0.5 * (width / 4)
     assert poly[2][0] == pytest.approx(width / 2 + expected + road_top / 2)

--- a/tests/test_sprite_loader.py
+++ b/tests/test_sprite_loader.py
@@ -12,5 +12,6 @@ def test_load_sprite_png(tmp_path, monkeypatch):
     pygame.image.save(img, str(fname))
     monkeypatch.setenv("SPRITE_DIR", str(tmp_path))
     surf = load_sprite("sample")
-    assert surf.get_size() == (4, 4)
+    assert surf.get_width() >= 32
+    assert surf.get_height() >= 32
     pygame.display.quit()

--- a/tests/test_sprite_size.py
+++ b/tests/test_sprite_size.py
@@ -1,0 +1,12 @@
+import pytest
+from super_pole_position.ui import sprites
+
+pygame = pytest.importorskip("pygame")
+
+
+def test_player_car_min_size() -> None:
+    pygame.display.init()
+    surf = sprites.load_sprite("player_car", sprites.CAR_ART)
+    assert surf.get_width() >= 32
+    assert surf.get_height() >= 32
+    pygame.display.quit()


### PR DESCRIPTION
## Summary
- ensure Pseudo3DRenderer uses a fixed 256x224 canvas
- pad loaded sprites to at least 32×32 pixels
- auto shift up in KeyboardAgent when speed is high
- document crisp canvas in README
- adjust rendering tests and add sprite size test

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603d28388083249f1e2ca3d3bc30a1